### PR TITLE
Force protocol upgrade and show message on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- added missing util `force-https` and it's tests
+### Changed
+- `feature-service-preview` will now auto-upgrade protocol to https regardless of the domain. If the request fails, we show an appropriate message.
+
 ## [0.5.1]
 ### Added
 - Add data-test data attribute to item-picker/item-preview and item-picker/feature-service-preview for use by e2e test element locator.

--- a/addon/components/image-with-fallback/component.js
+++ b/addon/components/image-with-fallback/component.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import forceHttps from 'ember-arcgis-opendata-components/utils/force-https';
+import forceHttps from 'ember-arcgis-portal-components/utils/force-https';
 
 // NOTE: the test for this is in
 // packages/opendata-ui/tests/integration/components/image-with-fallback/component-test.js
@@ -27,7 +27,8 @@ export default Ember.Component.extend({
 
   src: Ember.computed('imgSrcAry', 'imgIndex', function () {
     const imgSrc = this.get('imgSrcAry')[this.get('imgIndex')];
-    return forceHttps(imgSrc);
+    let protocol = window.location.protocol || 'http';
+    return forceHttps(imgSrc, protocol);
   }),
 
   onImageError () {

--- a/addon/utils/force-https.js
+++ b/addon/utils/force-https.js
@@ -1,0 +1,23 @@
+/**
+ * force (ish) a url to use https.
+ * Since we don't actually control the origin servers, these upgraded urls
+ * *may* not work. It's the consumer's issue to handle the failure.
+ */
+export default function forceHttps (url, currentProtocol = 'http') {
+  // upgrade to https if the current protocol is https
+  if (url && currentProtocol === 'https') {
+    return upgradeToHttps(url);
+  } else if (/\.arcgis\.com/.test(url)) {
+    // always upgrade for arcgis.com urls
+    return upgradeToHttps(url);
+  } else {
+    return url;
+  }
+}
+
+/**
+ * Upgrade a url to use https
+ */
+function upgradeToHttps (url) {
+  return url.replace(/^http:/i, 'https:');
+}

--- a/app/force-https/util.js
+++ b/app/force-https/util.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-arcgis-portal-components/force-https/util';

--- a/tests/unit/utils/force-https-test.js
+++ b/tests/unit/utils/force-https-test.js
@@ -1,0 +1,25 @@
+import forceHttps from 'ember-arcgis-portal-components/utils/force-https';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | force https');
+
+// Replace this with your real tests.
+test('it upgrades http to https for arcgis.com if protocol is https', function (assert) {
+  let result = forceHttps('http://foo.arcgis.com/some-path?query=string', 'https');
+  assert.equal(result, 'https://foo.arcgis.com/some-path?query=string');
+});
+
+test('it always upgrades for arcgis.com urls to https', function (assert) {
+  let result = forceHttps('http://foo.arcgis.com/some-path?query=string', 'http');
+  assert.equal(result, 'https://foo.arcgis.com/some-path?query=string');
+});
+
+test('it does upgrade non-arcgis.com urls to https if protocol is https', function (assert) {
+  let result = forceHttps('http://foo.com', 'https');
+  assert.equal(result, 'https://foo.com');
+});
+
+test('it returns https', function (assert) {
+  let result = forceHttps('https://foo.com');
+  assert.equal(result, 'https://foo.com');
+});

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -20,6 +20,9 @@
         "withQuery": "No items matched your search.",
         "withoutQuery": "No items found."
       },
+      "errors": {
+        "httpsNotSupported": "This service does not support HTTPS. Please update your server settings and try again."
+      },
       "buttons": {
         "back": "Back",
         "select": "Select",


### PR DESCRIPTION
Changed the protocol upgrade logic so that it always upgrades to https, but returns a `safe: true` flag if the domain is known (i.e. arcgis.com or arcgisonline.com). This allows orgs like DC, who have certs and host their data, but don't put `https` in the service item urls, to actually use their data.

If the network request fails, and it was an "unsafe" upgrade, we now show this message: 

![image](https://user-images.githubusercontent.com/119129/34699024-7434311e-f498-11e7-90b9-cbbd7f57c2e3.png)

You can test this by searching for HOPE in QA and getting to the `2013 Maryland HOPE Counseling Network Grant Awards` item.

Also added the missing util/force-https.js that was not included in a PR that moved the `image-with-fallback` component into this addon.

Tests pass, and this works in Admin via linking.