### PR TITLE
item-pager supports bootstrap 4 (by adding a few classes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Added
 - Readded `form-group` class for a11y
+- item-pager supports bootstrap 4 (by adding a few classes)
+### Fixed
+- added semi-colon to fix lint error
 
 ## [0.8.3]
 ### Added

--- a/addon/components/item-pager/component.js
+++ b/addon/components/item-pager/component.js
@@ -31,6 +31,12 @@ export default Component.extend({
 
   tagName: 'nav',
 
+  // TODO: since this component can be used independently
+  // I think it should have it's own scope, i.e.
+  // addons.components.itemPager, also
+  // in opendata-ui i18nScope does not include the trailing "."
+  _i18nScope: 'addons.components.itemPicker.',
+
   totalPages: computed('totalCount', function () {
     return Math.ceil(this.get('totalCount') / this.get('pageSize'));
   }),

--- a/addon/components/item-pager/template.hbs
+++ b/addon/components/item-pager/template.hbs
@@ -2,42 +2,42 @@
   <ul class="pagination">
     {{!-- If we're on the first page, do not display the link --}}
     {{#if isFirstPage}}
-      <li class="disabled">
-        <a aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&laquo;</a>
+      <li class="page-item disabled">
+        <a class="page-link" aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&laquo;</a>
       </li>
-      <li class="disabled">
-        <a aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&lsaquo;</a>
+      <li class="page-item disabled">
+        <a class="page-link" aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&lsaquo;</a>
       </li>
     {{else}}
-      <li>
-        <a href="" {{action changePage 1}} aria-label="{{t (concat _i18nScope 'aria.first_pg')}}">&laquo;</a>
+      <li class="page-item">
+        <a class="page-link" href="" {{action changePage 1}} aria-label="{{t (concat _i18nScope 'aria.first_pg')}}">&laquo;</a>
       </li>
-      <li>
-        <a href="" {{action changePage prevPage}} aria-label="{{t (concat _i18nScope 'aria.prev')}}">&lsaquo;</a>
+      <li class="page-item">
+        <a class="page-link" href="" {{action changePage prevPage}} aria-label="{{t (concat _i18nScope 'aria.prev')}}">&lsaquo;</a>
       </li>
     {{/if}}
 
     {{!-- For each page, display a link leading to it --}}
     {{#each pageRange as |num|}}
-      <li class="{{num.className}}">
-        <a href="" {{action changePage num.page}}>{{format-number num.page}}</a>
+      <li class="page-item {{num.className}}">
+        <a class="page-link" href="" {{action changePage num.page}}>{{format-number num.page}}</a>
       </li>
     {{/each}}
 
     {{!-- If we're on the last page, do not display the link --}}
     {{#if isLastPage}}
-      <li class="disabled">
-        <a aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&rsaquo;</a>
+      <li class="page-item disabled">
+        <a class="page-link" aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&rsaquo;</a>
       </li>
-      <li class="disabled">
-        <a aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&raquo;</a>
+      <li class="page-item disabled">
+        <a class="page-link" aria-label="{{t (concat _i18nScope 'aria.disabled')}}">&raquo;</a>
       </li>
     {{else}}
-      <li>
-        <a href="" {{action changePage nextPage}} aria-label="{{t (concat _i18nScope 'aria.next')}}">&rsaquo;</a>
+      <li class="page-item">
+        <a class="page-link" href="" {{action changePage nextPage}} aria-label="{{t (concat _i18nScope 'aria.next')}}">&rsaquo;</a>
       </li>
-      <li>
-        <a href="" {{action changePage lastPage}} aria-label="{{t (concat _i18nScope 'aria.last_pg')}}">&raquo;</a>
+      <li class="page-item">
+        <a class="page-link" href="" {{action changePage lastPage}} aria-label="{{t (concat _i18nScope 'aria.last_pg')}}">&raquo;</a>
       </li>
     {{/if}}
   </ul>

--- a/addon/components/item-picker/component.js
+++ b/addon/components/item-picker/component.js
@@ -87,7 +87,7 @@ export default Component.extend({
    * per-type UX for the preview
    */
   row: computed('rowComponent', function () {
-    return this.getWithDefault('rowComponent', 'item-picker/item-row')
+    return this.getWithDefault('rowComponent', 'item-picker/item-row');
   }),
 
   inputElementId: computed(function () {


### PR DESCRIPTION
also:
added default _i18nScope to item-pager so it is easier to use outside of item-picker
added semi-colon to fix lint error