### PR TITLE
Properly handle checkbox state

### DIFF
--- a/addon/components/item-picker/item-row/component.js
+++ b/addon/components/item-picker/item-row/component.js
@@ -14,6 +14,8 @@ import { computed } from '@ember/object';
 import Component from '@ember/component';
 import singleTemplate from './single/template';
 import multipleTemplate from './multiple/template';
+import { tryInvoke } from '@ember/utils';
+import { later } from '@ember/runloop';
 
 export default Component.extend({
   layout: computed('selectMultiple', function () {
@@ -60,8 +62,7 @@ export default Component.extend({
   }),
 
   checked: computed('model.id', 'itemsToAdd.[]', function () {
-    const itemsToAdd = this.get('itemsToAdd');
-    return !!itemsToAdd.findBy('id', this.get('model.id'));
+    return this.get('itemsToAdd').includes(this.get('model'));
   }),
 
   url: computed('model.id', 'session.portalHostname', function () {
@@ -70,11 +71,10 @@ export default Component.extend({
 
   actions: {
     selectItem (item) {
-      let model = {
-        item: item
-      };
-      this.get('onClick')(model);
-    },
+      later(this, () => {
+        tryInvoke(this, 'onClick', [{item}]);
+      }, 0);
+    }
   }
 
 });

--- a/addon/components/item-picker/item-row/multiple/template.hbs
+++ b/addon/components/item-picker/item-row/multiple/template.hbs
@@ -4,7 +4,7 @@
     <input type="checkbox" checked={{readonly checked}}>
   </div>
   <div class="item-picker-item-results-item-inner">
-    <h2 data-toggle="tooltip" title="{{model.title}}">
+    <h2>
       {{model.title}}
     </h2>
     <div class="shared-by">


### PR DESCRIPTION
The issue here was some weirdness around the runloop getting out of sync.

I _think_ something like this was happening:
1. When you click the checkbox it gets checked (apparently you cannot make html checkboxes readonly - that was the first thing I tried.)
2. The action fires and updates `itemsToAdd` which flows down appropriately via data binding.
3. The item-row/multiple/template.hbs re-renders but for some reason it does not pick up the new value of `checked`. I guess since the whole thing happens in a single runloop and starts with that checkbox being checked, glimmer gets confused. Or something.

Anyway, by putting the invocation of the action in the _next_ runloop, everything works as expected.