### PR TITLE
General Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ## Added
 - magic-checkbox class is now used in multi-select mode
+- markdown docs for item-picker
+## Changed
+- `feature-service-preview` action-up with `{item, options}`
+- `item-row` selectItem action uses `next`
+- general cleanup and consistency for using `model` internally, and returning `{item, options}`
+
 ## Fixed
 - Checkboxes no longer jump in Safari when checked [link](https://esriarlington.tpondemand.com/entity/83629-filter-by-initiative-styling-issues-withtooltips)
 - On smaller screens, the “Select” button on the bottom right now has a fixed width [link](https://esriarlington.tpondemand.com/entity/83629-filter-by-initiative-styling-issues-withtooltips)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The item picker component allows a user to search a portal for items, see a prev
 
 Layer picker is part of the item picker. It allows for items with multiple layers to display them as radio buttons. This will then allow the user to select which layer they would like to use. The layer picker will display by default if the item is type `Feature Service` or `Map Service`.
 
+## Contributing
+The components in this addon are used in MANY MANY places. As such, changes made to existing components, especially any external API surfaces is prone to having catastrophic downstream effects. Thus - before making any changes, please read and understand the [design document](./docs/design-docs.md). We are working on adding more unit and integration tests, but this will be an on-going process. Until we have a very high-level of coverage, modifications to these components should be considered a high-risk activity.
+
+
 ### Generating a New Component
 
 When generating a new component, please structure your files in the following order. This will help standardize the files and keep everything in an organized format:

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ ember install ember-arcgis-portal-components
 
 The item picker component allows a user to search a portal for items, see a preview of the item, and then get the item returned. While commonly used in a modal, the component can be used in any context.
 
-### Layer Picker
-
-Layer picker is part of the item picker. It allows for items with multiple layers to display them as radio buttons. This will then allow the user to select which layer they would like to use. The layer picker will display by default if the item is type `Feature Service` or `Map Service`.
+[Documentation](./docs/item-picker.md)
 
 ## Contributing
 The components in this addon are used in MANY MANY places. As such, changes made to existing components, especially any external API surfaces is prone to having catastrophic downstream effects. Thus - before making any changes, please read and understand the [design document](./docs/design-docs.md). We are working on adding more unit and integration tests, but this will be an on-going process. Until we have a very high-level of coverage, modifications to these components should be considered a high-risk activity.
@@ -51,17 +49,6 @@ When generating a new component, please structure your files in the following or
 6. Functions
 7. Actions
 
-## Options for Item Picker
-| Flag | Type | Required | Purpose |
-|----|:-------:|:-------:|----------|
-|   [selectAction](#default-usage-selectaction)   |     Function<br><small>(Closure Action)</small>      |   Yes   | This action is run when the `Select` button inside the item picker is pressed. This should be a closure action.   |
-|  [searchItemsOnInit](#search-on-initialize-searchitemsoninit)   |   Boolean   |No| Allows the item picker to execute a search and show the results as soon as it is rendered. This searches the active catalog on launch. If no active catalog is set, it will use the first available catalog. |
-|   [selectMultiple](#multi-select-selectmultiple)   |   Boolean      |  No|  Allows the item picker to select multiple items at once. An <strong>array</strong> of items will be passed to the closure action.   |
-|   [catalog](#facets-catalog)   |    Array         |   No   | Allows the item picker to be filtered based on ArcGIS Online (AGO) queries. If the `catalog` array has more than one entry, a "facets" list will be shown on the left of the component, and it will use the `name` property. |
-|   [onSelectionValidator](#validation-onselectionvalidator)   |    Function<br><small>(Closure Action)</small>  |   No   |    Allows an application to do more in-depth validation of an item before using it.  |
-|  [portalOpts](#portal-options-portalopts)    |   Object      |  No    |   Allows a different portal to be assigned to an item picker.       |
-|  [previewParams](#preview-params)    |   Object      |  No    |   Pass parameters to the Preview components       |
-|  [rowComponent](#custom-row-component-rowcomponent)    |   String<br><small>(Component)</small>      |  No    |   Allows a different row layout to be passed into the item picker.       |
 
 ### Examples
 
@@ -80,138 +67,6 @@ actions: {
     ...
   }
 }
-```
-
-
-
-#### Search on Initialize (searchItemsOnInit)
-
-```js
-{{item-picker
-  searchItemsOnInit=true
-  selectAction=(action "onSelectItem")}}
-```
-
-#### Multi-Select (selectMultiple)
-
-```js
-{{item-picker
-  selectMultiple=true
-  selectAction=(action "onSelectItem")}}
-```
-
-#### Facets (catalog)
-This code will have two facets on the left hand side of the component. `All` and `Waste Water Apps`
-
-In the controller:
-
-```js
-facets: [
-  {
-    name: 'All',
-    params: {query: { access: 'public'}}
-  },
-  {
-    name: 'Waste Water Apps',
-    params: {
-      query: {
-        type: ['Web Mapping Application'],
-        typekeywords: ['-story'],
-        tags: ['Waste Water']
-      }
-    }
-  }
-]
-```
-
-In the template:
-
-```js
-{{item-picker
-  searchItemsOnInit=true
-  catalog=facets
-  selectAction=(action "onSelectItem")}}
-```
-
-#### Preview Params
-Different Preview components are used depending on the type of the item. The `previewParams` is a means to send in some parameters to these components.
-
-| param | description |
-| --- | --- |
-| showLayers | Used by the `feature-service-preview` component, and will cause a list of layers to be shown. |
-| forceLayerSelection | Used by the `feature-service-preview` component, and force the user to select a layer/table. |
-
-
-#### Validation (onSelectionValidator)
-
-Validation functions should use the following signature `validate(item, options)`, and should return a `Promise` even if they don't do async operations. The selected item will always be passed in, but depending on the context, the options hash may contain additional information. For example, if a Map Service or Feature Service item is selected, the options hash will contain a `layer` object, allowing the validator to work with both the item and the specific layer.
-
-Valid status values are `ok`, `warning` and `error`. For warnings, the user will be given the option to select the item despite the warning. In the case of an error the item can not be selected.
-
-The message returned should be translated - do not rely on the item picker to translate messages.
-
-```js
-actions: {
-  selectionValidator(item, options) {
-    // validation logic
-    if (item.something) {
-      return resolve({
-        item: item,
-        status: {
-          status: 'error',
-          message: 'This item can not be used because ...'
-        }
-      });
-    } else {
-      // you can also manipulate the item here if you want...
-      return resolve({
-        item: item,
-        status: {
-          status: 'ok'
-        }
-      });
-    }
-  }
-}
-```
-
-In the template:
-
-```js
-{{item-picker
-      selectAction=(action "onSelectItem")
-      onSelectionValidator=(action "selectionValidator") }}
-```
-
-
-#### Portal Options (portalOpts)
-
-In the controller:
-
-```js
-// in Controller
-portalOpts: {
-  portalBaseUrl: 'https://someotherportal.com',
-  token: 'cb12---TOKEN-FOR-someotherportal.com---34..'
-}
-```
-In the template:
-
-```js
-{{item-picker
-      selectAction=(action "onSelectItem")
-      portalOpts=portalOpts }}
-```
-
-
-#### Custom Row Component (rowComponent)
-
-In the template:
-
-```js
-{{item-picker
-      selectAction=(action "onSelectItem")
-      rowComponent="name-of-custom-component" }}
 ```
 
 ### Setup

--- a/addon/components/item-picker/component.js
+++ b/addon/components/item-picker/component.js
@@ -20,12 +20,19 @@ import Component from '@ember/component';
 import layout from './template';
 import queryHelpers from 'ember-arcgis-portal-components/utils/query-helpers';
 import isGuid from 'ember-arcgis-portal-components/utils/is-guid';
-export default Component.extend({
-  layout,
-  intl: service(),
-  itemService: service('items-service'),
-  classNames: [ 'item-picker', 'clearfix' ],
 
+export default Component.extend({
+  classNames: [ 'item-picker', 'clearfix' ],
+  disableAddItems: not('hasItemsToAdd'),
+  hasItemsToAdd: notEmpty('itemsToAdd'),
+  intl: service(),
+  isValidating: false,
+  itemService: service('items-service'),
+  layout,
+  selectAnyway: false,
+  shouldValidate: false,
+  showMessage: notEmpty('currentMessage'),
+  showNoItemsMsg: notEmpty('noItemsFoundMsg'),
   /**
    * Startup the component... we may need to issue an immediate search...
    */
@@ -39,14 +46,6 @@ export default Component.extend({
       this._doSearch(this.get('q'));
     }
   },
-
-  disableAddItems: not('hasItemsToAdd'),
-  showNoItemsMsg: notEmpty('noItemsFoundMsg'),
-  hasItemsToAdd: notEmpty('itemsToAdd'),
-  showMessage: notEmpty('currentMessage'),
-  isValidating: false,
-  selectAnyway: false,
-  shouldValidate: false,
 
   /**
    * Compute the translation scope

--- a/addon/components/item-picker/feature-service-preview/component.js
+++ b/addon/components/item-picker/feature-service-preview/component.js
@@ -31,7 +31,7 @@ export default Component.extend({
   layout,
   selectAnyway: false,
   shouldValidate: false,
-  showError: notEmpty('errorMessage'),
+  showError: notEmpty('validationResult'),
 
   /**
    * Compute the translation scope
@@ -74,7 +74,7 @@ export default Component.extend({
   /**
    * Construct the preview url
    */
-  previewUrl: computed('model.item', function () {
+  previewUrl: computed('model', function () {
     const item = this.get('model.item');
     let previewURL;
     // if the item has a url property, use that...
@@ -100,13 +100,13 @@ export default Component.extend({
    * ... we have an error
    * ... we need to choose a layer, and have not selected one
    */
-  isSelectDisabled: computed('forceLayerSelection', 'selectedLayer', 'isValidating', 'errorMessage.status', function () {
-    const errorMessage = this.get('errorMessage');
+  isSelectDisabled: computed('forceLayerSelection', 'selectedLayer', 'isValidating', 'validationResult.status', function () {
+    const validationResult = this.get('validationResult');
     let result = false;
     if (this.get('isValidating')) {
       result = true;
     }
-    if (errorMessage && errorMessage.status && errorMessage.status === 'error') {
+    if (validationResult && validationResult.status && validationResult.status === 'error') {
       result = true;
     } else {
       if (this.get('forceLayerSelection') && this.get('selectedLayer') === null) {
@@ -200,7 +200,7 @@ export default Component.extend({
       .then((layersAndTables) => {
         this.setProperties({
           isLoading: false,
-          errorMessage: null,
+          validationResult: null,
           layerList: layersAndTables
         });
       })
@@ -211,7 +211,7 @@ export default Component.extend({
           selectedLayer: null,
         });
         debug(`Error fetching layers ${err}`);
-        this.set('errorMessage', {
+        this.set('validationResult', {
           status: 'error',
           message: err.message || 'Error accessing service.'
         });
@@ -258,10 +258,10 @@ export default Component.extend({
   /**
    * What class do we use for the message...
    */
-  messageClass: computed('errorMessage.status', function () {
-    if (this.get('errorMessage.status') === 'warning') {
+  messageClass: computed('validationResult.status', function () {
+    if (this.get('validationResult.status') === 'warning') {
       return 'alert-warning';
-    } else if (this.get('errorMessage.status') === 'error') {
+    } else if (this.get('validationResult.status') === 'error') {
       return 'alert-danger';
     }
   }),
@@ -291,7 +291,7 @@ export default Component.extend({
         validator(item)
           .then((resp) => {
             this.set('isValidating', false);
-            this.set('errorHash', resp.status);
+            this.set('validationResult', resp.status);
             if (resp.status.status === 'error') {
               return;
             } else if (resp.status.status === 'warning') {

--- a/addon/components/item-picker/feature-service-preview/component.js
+++ b/addon/components/item-picker/feature-service-preview/component.js
@@ -22,7 +22,7 @@ export default Component.extend({
   classNames: [ 'item-picker-current-item-preview' ],
   description: reads('model.item.description'),
   featureService: service('feature-service'),
-  forceLayerSelection: alias('showLayers'),
+  forceLayerSelection: alias('params.forceLayerSelection'),
   hasSelectedLayer: notEmpty('selectedLayer'),
   intl: service(),
   isLoading: true,
@@ -59,7 +59,6 @@ export default Component.extend({
   * ... a map service
   * ... a feature service
   */
-
   showLayers: computed('model.item.type', function () {
     const type = this.get('model.item.type');
     switch (type.toLowerCase()) {
@@ -148,6 +147,7 @@ export default Component.extend({
    */
   fetchServiceLayers (serviceItem) {
     const featureService = this.get('featureService');
+    serviceItem.url = serviceItem.url.trim();
     // upgrade the url and re-assign it to the item...
     let upgradeInfo = this.upgradeProtocol(serviceItem.url);
     serviceItem.url = upgradeInfo.url;
@@ -277,7 +277,7 @@ export default Component.extend({
     /**
      * When the user clicks the select button...
      */
-    onServiceSelected (item) {
+    onServiceSelected (model) {
       let options;
       if (this.get('forceLayerSelection')) {
         options = {
@@ -288,7 +288,7 @@ export default Component.extend({
 
       if (validator && typeof validator === 'function' && !this.get('selectAnyway')) {
         this.set('isValidating', true);
-        validator(item)
+        validator(model.item, options)
           .then((resp) => {
             this.set('isValidating', false);
             this.set('validationResult', resp.status);
@@ -298,11 +298,11 @@ export default Component.extend({
               this.set('selectAnyway', true);
               return;
             } else {
-              this.get('onItemSelected')(item, options);
+              this.get('onItemSelected')(model.item, options);
             }
           });
       } else {
-        this.get('onItemSelected')(item, options);
+        this.get('onItemSelected')(model.item, options);
       }
     }
   }

--- a/addon/components/item-picker/feature-service-preview/component.js
+++ b/addon/components/item-picker/feature-service-preview/component.js
@@ -278,9 +278,8 @@ export default Component.extend({
      * When the user clicks the select button...
      */
     onServiceSelected (model) {
-      let options;
       if (this.get('forceLayerSelection')) {
-        options = {
+        model.options = {
           layer: this.get('selectedLayer')
         };
       }
@@ -288,7 +287,7 @@ export default Component.extend({
 
       if (validator && typeof validator === 'function' && !this.get('selectAnyway')) {
         this.set('isValidating', true);
-        validator(model.item, options)
+        validator(model)
           .then((resp) => {
             this.set('isValidating', false);
             this.set('validationResult', resp.status);
@@ -298,11 +297,11 @@ export default Component.extend({
               this.set('selectAnyway', true);
               return;
             } else {
-              this.get('onItemSelected')(model.item, options);
+              this.get('onItemSelected')(model.item, model.options);
             }
           });
       } else {
-        this.get('onItemSelected')(model.item, options);
+        this.get('onItemSelected')(model.item, model.options);
       }
     }
   }

--- a/addon/components/item-picker/feature-service-preview/template.hbs
+++ b/addon/components/item-picker/feature-service-preview/template.hbs
@@ -21,10 +21,14 @@
   {{else}}
       {{#if showError}}
         <p class="alert {{messageClass}}" id="val-error">
-          {{errorMessage.message}}
+          {{validationResult.message}}
         </p>
       {{else}}
-        {{item-picker/layer-picker model=layerList selectable=forceLayerSelection onLayerSelected=(action "onLayerSelected")}}
+        {{item-picker/layer-picker
+          model=layerList
+          i18nScope=_i18nScope
+          selectable=forceLayerSelection
+          onLayerSelected=(action "onLayerSelected")}}
       {{/if}}
   {{/if}}
   </section>

--- a/addon/components/item-picker/item-preview/component.js
+++ b/addon/components/item-picker/item-preview/component.js
@@ -32,7 +32,7 @@ export default Component.extend({
   isValidating: false,
   selectAnyway: false,
   shouldValidate: false,
-  showError: notEmpty('errorMessage'),
+  showError: notEmpty('validationResult'),
   description: reads('model.item.description'),
 
   /**
@@ -98,10 +98,10 @@ export default Component.extend({
   /**
    * What class should be used for any messages
    */
-  messageClass: computed('errorMessage', function () {
-    if (this.get('errorMessage.status') === 'warning') {
+  messageClass: computed('validationResult', function () {
+    if (this.get('validationResult.status') === 'warning') {
       return 'alert-warning';
-    } else if (this.get('errorMessage.status') === 'error') {
+    } else if (this.get('validationResult.status') === 'error') {
       return 'alert-danger';
     }
   }),
@@ -115,7 +115,7 @@ export default Component.extend({
         validator(item)
           .then((resp) => {
             this.set('isValidating', false);
-            this.set('errorHash', resp.status);
+            this.set('validationResult', resp.status);
             if (resp.status.status === 'error') {
               return;
             } else if (resp.status.status === 'warning') {

--- a/addon/components/item-picker/item-preview/template.hbs
+++ b/addon/components/item-picker/item-preview/template.hbs
@@ -1,6 +1,6 @@
 {{#if showError}}
   <p class="alert {{messageClass}}" id="val-error">
-    {{errorMessage.message}}
+    {{validationResult.message}}
   </p>
 {{/if}}
 {{image-with-fallback imgSrc=thumbnailUrl fallbackSrc='ember-arcgis-portal-components/assets/images/default-dataset-thumb.png'}}

--- a/addon/components/item-picker/item-row/component.js
+++ b/addon/components/item-picker/item-row/component.js
@@ -15,7 +15,7 @@ import Component from '@ember/component';
 import singleTemplate from './single/template';
 import multipleTemplate from './multiple/template';
 import { tryInvoke } from '@ember/utils';
-import { later } from '@ember/runloop';
+import { next } from '@ember/runloop';
 
 export default Component.extend({
   layout: computed('selectMultiple', function () {
@@ -72,9 +72,11 @@ export default Component.extend({
 
   actions: {
     selectItem (item) {
-      later(this, () => {
+      // this is needed because of what appears to be a glimmer race condition.
+      // if not present, the checked state of the checkbox will be out of sync
+      next(this, () => {
         tryInvoke(this, 'onClick', [{item}]);
-      }, 0);
+      });
     }
   }
 

--- a/addon/components/item-picker/item-row/component.js
+++ b/addon/components/item-picker/item-row/component.js
@@ -62,7 +62,8 @@ export default Component.extend({
   }),
 
   checked: computed('model.id', 'itemsToAdd.[]', function () {
-    return this.get('itemsToAdd').includes(this.get('model'));
+    let chk = this.get('itemsToAdd').includes(this.get('model'));
+    return chk;
   }),
 
   url: computed('model.id', 'session.portalHostname', function () {

--- a/addon/components/item-picker/item-row/multiple/template.hbs
+++ b/addon/components/item-picker/item-row/multiple/template.hbs
@@ -9,11 +9,7 @@
       {{model.title}}
     </h2>
     <div class="shared-by">
-      {{#if events}}
-        ({{numberOfItems}}) {{t (concat _i18nScope "relatedEvents") }}
-      {{else}}
         {{model.owner}}
-      {{/if}}
     </div>
   </div>
 </a>

--- a/addon/components/item-picker/layer-picker-row/component.js
+++ b/addon/components/item-picker/layer-picker-row/component.js
@@ -1,0 +1,24 @@
+import Component from '@ember/component';
+import layout from './template';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+export default Component.extend({
+  layout,
+  intl: service(),
+  /**
+   * Compute the translation scope
+   */
+  _i18nScope: computed('i18nScope', function () {
+    return `${this.getWithDefault('i18nScope', 'addons.components.itemPicker')}.`;
+  }),
+  /**
+   * Compute the i18n key for the geometry type and return that
+   */
+  geometryTypeKey: computed('layer', function () {
+    let layer = this.get('layer');
+    let type = layer.geometryType || 'table';
+    let key = `${this.get('_i18nScope')}shared.geometryType.${type}`;
+    console.debug(`Key is ${key}`);
+    return key;
+  })
+});

--- a/addon/components/item-picker/layer-picker-row/template.hbs
+++ b/addon/components/item-picker/layer-picker-row/template.hbs
@@ -1,0 +1,12 @@
+{{#if selectable}}
+<input
+  type="radio"
+  name="selectedLayer"
+  checked={{layer.checked}}
+  value={{layer.id}}
+  class="magic-radio"
+  id={{layer.name}}
+  onchange={{action onLayerSelected layer}}
+/>
+{{/if}}
+<label for="{{layer.name}}">{{layer.name}} ({{t geometryTypeKey }})</label>

--- a/addon/components/item-picker/layer-picker/component.js
+++ b/addon/components/item-picker/layer-picker/component.js
@@ -11,15 +11,7 @@
 
 import Component from '@ember/component';
 import layout from './template';
-import { inject as service } from '@ember/service';
 export default Component.extend({
   layout,
-  intl: service(),
-  /**
-   * Compute the i18n key for the geometry type and return that
-   */
-  geometryTypeKey: computed('layer.geometryType', function () {
-    let key = `$this.get('i18nScope')}.shared.geometryType.${this.get('layer.geometryType')}`;
-    return key;
-  })
+
 });

--- a/addon/components/item-picker/layer-picker/component.js
+++ b/addon/components/item-picker/layer-picker/component.js
@@ -11,7 +11,15 @@
 
 import Component from '@ember/component';
 import layout from './template';
-
+import { inject as service } from '@ember/service';
 export default Component.extend({
-  layout
+  layout,
+  intl: service(),
+  /**
+   * Compute the i18n key for the geometry type and return that
+   */
+  geometryTypeKey: computed('layer.geometryType', function () {
+    let key = `$this.get('i18nScope')}.shared.geometryType.${this.get('layer.geometryType')}`;
+    return key;
+  })
 });

--- a/addon/components/item-picker/layer-picker/template.hbs
+++ b/addon/components/item-picker/layer-picker/template.hbs
@@ -12,7 +12,7 @@
         onchange={{action onLayerSelected layer}}
       />
       {{/if}}
-      <label for="{{layer.name}}">{{layer.name}}</label>
+      <label for="{{layer.name}}">{{layer.name}} ({{t geometryTypeKey}})</label>
     {{/each}}
   </ul>
 </div>

--- a/addon/components/item-picker/layer-picker/template.hbs
+++ b/addon/components/item-picker/layer-picker/template.hbs
@@ -1,18 +1,11 @@
 <div class="layer-picker-list">
   <ul class="nav nav-pills nav-stacked">
     {{#each model as |layer|}}
-      {{#if selectable}}
-      <input
-        type="radio"
-        name="selectedLayer"
-        checked={{layer.checked}}
-        value={{layer.id}}
-        class="magic-radio"
-        id={{layer.name}}
-        onchange={{action onLayerSelected layer}}
-      />
-      {{/if}}
-      <label for="{{layer.name}}">{{layer.name}} ({{t geometryTypeKey}})</label>
+      {{item-picker/layer-picker-row
+        layer=layer
+        selectable=selectable
+        onLayerSelected=(action onLayerSelected)
+      }}
     {{/each}}
   </ul>
 </div>

--- a/addon/utils/query-helpers.js
+++ b/addon/utils/query-helpers.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 /**
- * blah
+ * Create the query from the datalog, searchString
  */
 function createQuery (catalog, searchString, isHex) {
   const queryParts = A([]);

--- a/app/components/item-picker/layer-picker-row/component.js
+++ b/app/components/item-picker/layer-picker-row/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-arcgis-portal-components/components/item-picker/layer-picker-row/component';

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,22 @@
+# TODO List
+
+## Item Row
+- remove event stuff
+
+## Validation
+
+Returning an object like
+```json
+{
+  "model": {...},
+  "status": {
+    "status": "warning"
+  }
+}
+```
+seems goofy. We should change the internal `.status` to `.value` or the outer to `.validation`.
+
+
+## Extension
+
+- add a means to specify a preview component

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,11 @@
 # TODO List
 
+## Docs
+- component hierarchy and descriptions
+
+## Component Refactoring
+
+- extract `facets-list` into a component
 
 ## Validation
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,5 @@
 # TODO List
 
-## Item Row
-- remove event stuff
 
 ## Validation
 

--- a/docs/design-docs.md
+++ b/docs/design-docs.md
@@ -1,21 +1,6 @@
 # Design Docs
 
-## Components
+This addon contains multiple components, design docs for each are in separate files:
 
-### Item Picker
-
-`{{item-picker
-  selectAction=(action "onSelectItem")
-  selectMultiple=true
-  searchItemsOnInit=true
-  onSelectionValidator=(action "selectionValidator")
-  }}`
-
-
-
-
-Internally to the item picker components (including custom rows/preview components) use a model instead of just an item. The model has the format of `{item: {...}, options: {...}}`.
-
-The options hash can contain many different things depending on the context.
-
-For example - the `feature-service-preview` will use the `options` hash to pass forward the selected layer, along with the item to validation functions.
+- [item-picker](item-picker.md)
+- [search-form](search-form.md)

--- a/docs/design-docs.md
+++ b/docs/design-docs.md
@@ -1,0 +1,21 @@
+# Design Docs
+
+## Components
+
+### Item Picker
+
+`{{item-picker
+  selectAction=(action "onSelectItem")
+  selectMultiple=true
+  searchItemsOnInit=true
+  onSelectionValidator=(action "selectionValidator")
+  }}`
+
+
+
+
+Internally to the item picker components (including custom rows/preview components) use a model instead of just an item. The model has the format of `{item: {...}, options: {...}}`.
+
+The options hash can contain many different things depending on the context.
+
+For example - the `feature-service-preview` will use the `options` hash to pass forward the selected layer, along with the item to validation functions.

--- a/docs/item-picker.md
+++ b/docs/item-picker.md
@@ -254,3 +254,21 @@ The component will be used in the following context, and developers should refer
   onClick=(action "onItemClick") // action you can fire to inform the rest of the item picker of a selection
   }}
 ```
+
+#### Handling Multiple Selection
+
+Multiple selection is usually handled by showing a `<input type="checkbox"...` and there are some idiosyncrasies with getting event handlers and the checked state to be in sync.
+
+What we've found is that the use of a `next` in the component's `selectItem` action solves this. This example code is from the `item-row` component.
+
+```js
+actions: {
+  selectItem (item) {
+    // this is needed because of what appears to be a glimmer race condition.
+    // if not present, the checked state of the checkbox will be out of sync
+    next(this, () => {
+      tryInvoke(this, 'onClick', [{item}]);
+    });
+  }
+}
+```

--- a/docs/item-picker.md
+++ b/docs/item-picker.md
@@ -1,0 +1,256 @@
+# Item Picker
+
+The Item Picker encapsulates the selection of Items. At first this seems like a relatively straight-forward task, but, as we will see, there are a great many permutations that need to be addressed.
+
+## Concepts and Usage
+
+### Internal Model
+Internally, the item picker components use a `model` instead of just an `item`. The model has the format of:
+
+```json
+{
+  "item": {...},
+  "options": {...}
+}
+```
+
+The options hash can contain many different things depending on the context.
+
+### Basic Usage
+
+Item selection is the main purpose of the item picker, so it's no surprise that we pass the component an action. Since these handlers run "outside" the item picker, they *are not* passed a `model`. Instead two parameters are passed - the `item`, and an `options` hash.
+
+```hbs
+{{item-picker
+    selectAction=(action "onSelectItem")}}
+```
+
+The selectAction handler will be passed the selected item, and it may be passed a second `options` param which will contain contextually specific content. For example, if the item selected is a Feature Service, then the Preview will show a layer picker list. The selected layer will be pass in the options as `{layer: {...}}`
+
+```js
+actions: {
+  onSelectItem(item, options) {
+    // do something with the item
+  }
+}
+```
+
+By default, the item picker will wait for the user to enter a query before issuing a search. If you want it to issue a query as soon as it's displayed, set the `searchItemsOnInit` attribute to true.
+
+```hbs
+{{item-picker
+    searchItemsOnInit=true
+    selectAction=(action "onSelectItem")}}
+```
+
+### Multiple Selection
+
+There are scenarios where a user needs to select multiple items. This is supported by passing in `selectMultiple=true`.
+
+```hbs
+{{item-picker
+    selectMultiple=true
+    selectAction=(action "onSelectItem")}}
+```
+
+In this mode, clicking on a row in the item picker will toggle that item's selected state. If a validator has been passed in, the validator will also fire.
+
+Clicking "Select" at the bottom of the Item Picker UI will call the `selectAction` and pass in an array containing the selected items.
+
+### Specifying Portal Instance
+
+By default, item picker will search public items in ArcGIS Online. If you are using the `torii-provider-arcgis`, and the user is authenticated, it will search the portal the user is authenticated against. This covers the vast majority of scenarios. However, there are scenarions in ArcGIS Hub when we need to specify a different portal instance than what the current user (or anon user) is authenticated against. The item picker supports this via the `portalOpts` attribute.
+
+In the controller setup an object like this...
+
+```js
+portalOpts: {
+  portalBaseUrl: 'https://someotherportal.com',
+  token: 'cb12---TOKEN-FOR-someotherportal.com---34..'
+}
+```
+
+And pass that into the item picker via the `portalOpts` attribute.
+
+```js
+{{item-picker
+      selectAction=(action "onSelectItem")
+      portalOpts=portalOpts }}
+```
+
+
+### Filtering and Faceting
+
+As a developer using the item picker we need to be able to pass the component some sort of filter - say restricting the selection to Web Maps. To do this we pass a hash into the item picker via the `catalog` attribute.
+
+The `catalog` must be an array. If there are more than one entry, then the item picker UI will show a list of "facets" along the side. If only one element is passed in, then the "facets" panel is not shown, and the filter is applied to all queries.
+
+#### Catalog Structure
+The catalog structure is very flexible and allows the developer to use any ArcGIS Portal/Online Search parameter
+
+```json
+[
+  {
+    "name": "All",
+    "params": {
+      "query": {
+        "access": "public"
+      }
+    }
+  },
+  {
+    "name": "Waste Water Apps",
+    "params": {
+      "query": {
+        "type": ["Web Mapping Application"],
+        "typekeywords": ["-story"],
+        "tags": ["Waste Water"]
+      }
+    }
+  }
+]
+```
+
+The `name` property will be shown in the facets panel, and thus should be internationalized when the catalog structure is created.
+
+The child properties of the `query` property will be serialized into the ArcGIS Search API `q` property, along with the text string the user enters in the item picker. Please look at the [query-helpers.js](/addon/utils/query-helpers.js) for details about how this is all serialized.
+
+### Item Validation
+
+Although the ArcGIS Search API is quite powerful, there are times when we need to do additional inspection or validation of the selected item before we can allow the user to choose it. Since these validations are specific to the context in which the item picker is used, we allow the developer to pass in a validation function via the `onSelectionValidator` property.
+
+#### Validation Function Signature
+
+Since validation functions operate "internal" to the item-picker, they work with the `model` structure outlined above.
+Validation functions should use the following signature `validate(model)`, and should return a `Promise` even if it is not doing async operations. The `model.item` will always be present in, but depending on the context, `model.options` hash may contain additional information. For example, if a Map Service or Feature Service item is selected, the `model.options` hash will contain a `layer` object, allowing the validator to work with both the item and the specific layer.
+
+#### Validation Return Values
+
+Validation functions must return a `Promise`, and should return an object with the following structure:
+
+```json
+{
+  "model": {
+    "item": {...},
+    "options": {...}
+  },
+  "status": {
+    "status": "ok|warning|error",
+    "message": "Message shown to user in the ui"
+  }
+}
+```
+
+Valid status values are `ok`, `warning` and `error`.
+
+For warnings, the user will be given the option to select the item despite the warning.
+
+In the case of an error the item can not be selected.
+
+*Note:* The message returned should be translated - do not rely on the item picker to translate messages.
+
+#### Example Code
+
+In the template of a component that is using an item picker...
+
+```hbs
+{{item-picker
+    selectAction=(action "onSelectItem")
+    onSelectionValidator=(action "selectionValidator") }}
+```
+
+Then, in that component's js file, we'd have an action...
+
+```js
+actions: {
+  selectionValidator(model) {
+    // validation logic
+    if (model.item.something) {
+      return resolve({
+        model: model,
+        status: {
+          status: 'error',
+          message: 'This item can not be used because ...'
+        }
+      });
+    } else {
+      // you can also manipulate the item here if you want...
+      return resolve({
+        model: model,
+        status: {
+          status: 'ok'
+        }
+      });
+    }
+  }
+}
+```
+
+### Type-Specific Preview
+
+When not in multi-select mode, clicking on an item in the result list, will show the "Preview". The item picker has two built-in Preview components.
+
+#### Generic Item Preview
+
+This is the default preview component, and it simply shows basic info about the item. Any validation errors/warnings will be injected into the UI.
+
+#### Feature Service Preview
+
+This component is used for Map Service, Feature Service or Feature Layer items. It also shows basic Item information, but it can also list the layers in the service and/or force the user to choose a layer. When this is used, the validation function will recieve the selected layer in the `model.options` hash.
+
+#### Layer Selection
+
+Many places in the Hub workflows, the user needs to select a layer. The Feature Service Preview allows us to require a layer selection. This is done using the `previewParams` attribute.
+
+| param | description |
+| --- | --- |
+| showLayers | Used by the `feature-service-preview` component, and will cause a list of layers to be shown. |
+| forceLayerSelection | Used by the `feature-service-preview` component, and force the user to select a layer/table. |
+
+
+```hbs
+{{item-picker
+    selectAction=(action "onSelectItem")
+    previewParams=params
+    onSelectionValidator=(action "selectionValidator") }}
+```
+
+ and in the component...
+
+```js
+  ...
+  params = {
+    showLayers: true,
+    forceLayerSelection: true
+  }
+  ...
+```
+
+## Extending Item Picker
+
+Since it is impossible to for-see all the possible permutations of how an item picker could be used, the component exposes some extensibility points.
+
+### Custom Row Components
+
+If you need to customize how a row in the results list is displayed, you can create your own component and then tell the item picker to use that by setting the `rowComponent` attribute to the name of the component you want to use.
+
+
+```hbs
+{{item-picker
+    selectAction=(action "onSelectItem")
+    rowComponent="name-of-custom-component" }}
+```
+
+The component will be used in the following context, and developers should refer to the `item-row` component for details
+
+```hbs
+{{component rowComponent
+  selectMultiple=selectMultiple // select multiple flag
+  itemsToAdd=itemsToAdd // array that you can add the item
+  _i18nScope=_i18nScope // i18n scope
+  onSelectionValidator=onSelectionValidator // validator
+  model=item // the item
+  currentItemId=currentModel.item.id // for non-multi-select, this is the currently selected itemid
+  onClick=(action "onItemClick") // action you can fire to inform the rest of the item picker of a selection
+  }}
+```

--- a/docs/item-picker.md
+++ b/docs/item-picker.md
@@ -2,6 +2,21 @@
 
 The Item Picker encapsulates the selection of Items. At first this seems like a relatively straight-forward task, but, as we will see, there are a great many permutations that need to be addressed.
 
+## Options for Item Picker
+
+| Attribute | Type | Required | Purpose |
+|----|:-------:|:-------:|----------|
+|  [selectAction](#basic-usage) | Function<br><small>(Closure Action)</small> | Yes | This action is run when the `Select` button inside the item picker is pressed. This should be a closure action. |
+|  [searchItemsOnInit](#basic-usage) | Boolean | No | Allows the item picker to execute a search and show the results as soon as it is rendered. This searches the active catalog on launch. If no active catalog is set, it will use the first available catalog. |
+|  [selectMultiple](#multiple-selection) | Boolean |  No|  Allows the item picker to select multiple items at once. An <strong>array</strong> of items will be passed to the closure action.   |
+|  [catalog](#filterin-and-faceting)  |  Array |  No | Allows the item picker to be filtered based on ArcGIS Online (AGO) queries. If the `catalog` array has more than one entry, a "facets" list will be shown on the left of the component, and it will use the `name` property. |
+|  [onSelectionValidator](#item-validation) | Function<br><small>(Closure Action)</small>  | No | Allows an application to do more in-depth validation of an item before using it. |
+|  [portalOpts](#specifying-portal-instance) | Object | No |   Allows searches to be run against different portal instances. |
+|  [previewParams](#layer-selection) | Object |  No    |   Pass parameters to the Preview components, notably forcing layer selection |
+|  [rowComponent](#custom-row-components) | String<br><small>(Component)</small> | No |   Name of a component to use when rendering the rows. |
+
+
+
 ## Concepts and Usage
 
 ### Internal Model
@@ -255,6 +270,10 @@ The component will be used in the following context, and developers should refer
   }}
 ```
 
+### Custom Preview Components
+
+This will be supported in the future, but the intent is to allow the developer to specify a component that will be used for the "Preview". This component will need to handle any type of item that the associated catalog allows.
+
 #### Handling Multiple Selection
 
 Multiple selection is usually handled by showing a `<input type="checkbox"...` and there are some idiosyncrasies with getting event handlers and the checked state to be in sync.
@@ -272,3 +291,7 @@ actions: {
   }
 }
 ```
+
+## Child Components
+
+The item picker is composed of many child components. TODO: Add more docs / images here

--- a/tests/dummy/app/itempicker/validation/controller.js
+++ b/tests/dummy/app/itempicker/validation/controller.js
@@ -5,7 +5,7 @@ import Controller from '@ember/controller';
 import fetch from 'ember-network/fetch';
 
 export default Controller.extend({
-  selectedItem: null,
+  selectedModel: null,
 
   itemService: service('items-service'),
 
@@ -26,7 +26,7 @@ export default Controller.extend({
     }
   },
 
-  _validator (item) {
+  _validator (item, options) {
     const copyItem = copy(item, true);
     const isHttp = /^(http:)\/\//;
     const url = `${copyItem.url.replace(/\s+/g, '')}?f=json`;
@@ -91,9 +91,15 @@ export default Controller.extend({
   },
 
   actions: {
-    onSelectItem (selected) {
+    onSelectItem (item, options) {
       $('#myModal').modal('hide');
-      this.set('selectedItem', selected);
+      let model = {
+        item: item
+      };
+      if (options && options.layer) {
+        model.layer = options.layer;
+      }
+      this.set('selectedModel', model);
     },
 
     selectionValidator (item) {

--- a/tests/dummy/app/itempicker/validation/template.hbs
+++ b/tests/dummy/app/itempicker/validation/template.hbs
@@ -11,15 +11,24 @@
       selectAction=(action "onSelectItem")
       onSelectionValidator=(action "selectionValidator") }}' }}
     </pre>
+    <p>The validation function should have the following signature: </p>
+    <code>validator(item, options)</code>
+    <p>Where <code>options</code> may contain custom properties such as the selected layer etc.</p>
+
   </div>
   <div class="col-sm-6">
     <h3>Selected Item </h3>
-    {{#if selectedItem}}
+    {{#if selectedModel}}
       <div class="panel panel-default">
-        <div class="panel-heading"><h3 class="panel-title">{{selectedItem.title}}</h3></div>
+        <div class="panel-heading"><h3 class="panel-title">{{selectedModel.item.title}}</h3></div>
         <div class="panel-body">
-          {{sanitize-html selectedItem.description}}
+          {{sanitize-html selectedModel.item.description}}
         </div>
+        {{#if selectedModel.layer}}
+        <div class="panel-body">
+          Layer: {{selectedModel.layer.name}}
+        </div>
+        {{/if}}
       </div>
     {{else}}
       <div class="alert alert-warning" role="alert">
@@ -57,7 +66,7 @@
         <h4 class="modal-title" id="myModalLabel">Default Usage</h4>
       </div>
       <div class="modal-body">
-        {{item-picker 
+        {{item-picker
           selectAction=(action "onSelectItem")
           onSelectionValidator=(action "selectionValidator")}}
       </div>

--- a/tests/integration/components/item-picker/feature-service-preview/component-test.js
+++ b/tests/integration/components/item-picker/feature-service-preview/component-test.js
@@ -35,7 +35,7 @@ test('it renders', function (assert) {
   };
 
   this.setProperties({
-    currentItem: item,
+    currentItem: {item: item},
     isLoading: false,
     layerList: [],
     selectedLayer: null,

--- a/tests/integration/components/item-picker/item-preview/component-test.js
+++ b/tests/integration/components/item-picker/item-preview/component-test.js
@@ -11,7 +11,7 @@ moduleForComponent('item-picker/item-preview', 'Integration | Component | item p
 
 test('it renders', function (assert) {
   const id = 'test-dataset-id';
-  const model = {
+  const item = {
     id: id,
     title: 'This is the name',
     description: 'This is the description',
@@ -20,7 +20,7 @@ test('it renders', function (assert) {
     type: 'Web Map'
   };
 
-  this.set('model', model);
+  this.set('model', {item: item});
   this.set('onSelectionValidator', function () {});
   this.set('onItemSelected', function () {});
   this.set('cancelAction', function () {});

--- a/tests/integration/components/item-picker/item-row/component-test.js
+++ b/tests/integration/components/item-picker/item-row/component-test.js
@@ -51,15 +51,15 @@ test('it renders selected', function (assert) {
 
 test('it properly handles click', function (assert) {
   const id = 'test-dataset-id';
-  const model = { id: id, title: 'This is the name' };
+  const item = { id: id, title: 'This is the name' };
   this.setProperties({
     currentItemId: id,
-    model: model
+    model: item
   });
 
   // test double for the external action
-  this.set('onClick', (item) => {
-    assert.equal(item.id, id, 'submitted value is passed to external action');
+  this.set('onClick', (model) => {
+    assert.equal(item.id, model.item.id, 'submitted value is passed to external action');
   });
 
   this.render(hbs`{{item-picker/item-row model=model currentItemId=currentItemId onClick=(action onClick)}}`);
@@ -107,15 +107,15 @@ test('multiple-mode: it renders checked', function (assert) {
 
 test('multiple-mode: it properly handles click', function (assert) {
   const id = 'test-dataset-id';
-  const model = { id: id, title: 'This is the name' };
+  const item = { id: id, title: 'This is the name' };
   this.setProperties({
-    model: model,
+    model: item,
     itemsToAdd: []
   });
 
   // test double for the external action
-  this.set('onClick', (item) => {
-    assert.equal(item.id, id, 'submitted value is passed to external action');
+  this.set('onClick', (model) => {
+    assert.equal(item.id, model.item.id, 'submitted value is passed to external action');
   });
 
   this.render(hbs`{{item-picker/item-row model=model selectMultiple=true itemsToAdd=itemsToAdd currentItemId=currentItemId onClick=(action onClick)}}`);

--- a/tests/integration/components/item-picker/item-row/component-test.js
+++ b/tests/integration/components/item-picker/item-row/component-test.js
@@ -73,18 +73,24 @@ test('multiple-mode: it renders', function (assert) {
   });
 
   const id = 'test-item-id';
-  const model = { id: id, title: 'This is the name' };
+  const model = { id: id, title: 'This is the name', type: 'Web Map', owner: 'vader' };
   this.setProperties({
     model: model,
     itemsToAdd: []
   });
-  this.render(hbs`{{item-picker/item-row model=model selectMultiple=true itemsToAdd=itemsToAdd currentItemId=currentItemId onClick=(action onClick item)}}`);
+  this.render(hbs`{{item-picker/item-row
+    model=model
+    selectMultiple=true
+    itemsToAdd=itemsToAdd
+    currentItemId=currentItemId
+    onClick=(action onClick item)}}`);
 
   assert.equal(this.$('h2').text().trim(), 'This is the name');
-  assert.equal(this.$('.item-picker-item-results-item span').length, 1);
-  assert.equal(this.$('.item-picker-item-results-item a').length, 1);
-  assert.equal(this.$('.item-picker-item-results-item a input').length, 1);
-  assert.notOk(this.$('.item-picker-item-results-item a input').is(':checked'));
+  assert.equal(this.$('.shared-by').text().trim(), 'vader');
+  assert.equal(this.$('.checkbox-inline span').length, 1, 'should be one span');
+  assert.equal(this.$('.item-picker-item-results-item a').length, 1, 'should be one a');
+  assert.equal(this.$('.item-picker-item-results-item a input').length, 1, 'should be one a input');
+  assert.notOk(this.$('.item-picker-item-results-item a input').is(':checked'), 'input should not be checked');
 });
 
 test('multiple-mode: it renders checked', function (assert) {
@@ -94,15 +100,21 @@ test('multiple-mode: it renders checked', function (assert) {
   });
 
   const id = 'test-item-id';
-  const model = { id: id, title: 'This is the name' };
+  const model = { id: id, title: 'This is the name', type: 'Web Map', owner: 'vader' };
   this.setProperties({
     model: model,
-    itemsToAdd: [ { id: id } ]
+    itemsToAdd: [ model ]
   });
-  this.render(hbs`{{item-picker/item-row model=model selectMultiple=true itemsToAdd=itemsToAdd currentItemId=currentItemId onClick=(action onClick item)}}`);
+  this.render(hbs`{{item-picker/item-row
+    model=model
+    selectMultiple=true
+    itemsToAdd=itemsToAdd
+    currentItemId=currentItemId
+    onClick=(action onClick item)}}`);
 
   assert.equal(this.$('h2').text().trim(), 'This is the name');
-  assert.ok(this.$('.item-picker-item-results-item a input').is(':checked'));
+  assert.equal(this.$('.shared-by').text().trim(), 'vader');
+  assert.ok(this.$('.item-picker-item-results-item a input').is(':checked'), 'should be checked');
 });
 
 test('multiple-mode: it properly handles click', function (assert) {

--- a/tests/integration/components/item-picker/layer-picker-row/component-test.js
+++ b/tests/integration/components/item-picker/layer-picker-row/component-test.js
@@ -1,0 +1,46 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+moduleForComponent('item-picker/layer-picker-row', 'Integration | Component | item picker/layer picker row', {
+  integration: true,
+  setup () {
+    let intl = this.container.lookup('service:intl');
+    intl.setLocale('en-us');
+
+    const session = Service.extend({});
+    this.register('service:session', session);
+  },
+});
+
+test('it renders a layer with type', function (assert) {
+  this.set('layer', {
+    geometryType: 'esriGeometryPoint',
+    name: 'The Layer'
+  });
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.render(hbs`{{item-picker/layer-picker-row
+    layer=layer
+    selectable=false
+  }}`);
+  assert.equal(this.$('label').text().trim(), 'The Layer (Point)');
+});
+
+test('it renders a radio layer with type', function (assert) {
+  let layer = {
+    geometryType: 'esriGeometryPoint',
+    name: 'The Layer'
+  };
+  this.setProperties({
+    layer: layer,
+    onLayerSelected: function () {}
+  });
+  // Handle any actions with this.on('myAction', function(val) { ... });
+  this.render(hbs`{{item-picker/layer-picker-row
+    layer=layer
+    selectable=true
+    onLayerSelected=(action onLayerSelected)
+  }}`);
+  assert.equal(this.$('label').text().trim(), 'The Layer (Point)');
+  assert.equal(this.$('input[type=radio]').length, 1, 'Should be one input');
+});

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -77,6 +77,14 @@
             "imageService": "Image Service",
             "webMap": "Web Map",
             "webMappingApplication": "Web Mapping Application"
+          },
+          "geometryType": {
+            "esriGeometryPolygon": "Polygon",
+            "esriGeometryLine": "Line",
+            "esriGeometryPoint": "Point",
+            "esriGeometryMultipoint": "Multipoint",
+            "esriGeometryPolyline": "Polyline",
+            "table": "Table"
           }
         }
       }


### PR DESCRIPTION
This addresses a number of internal and external inconsistencies...

- `feature-service-preview` 
   - updated to use `model` internally
   - rename `errorMessage` to `validationResult` to better express intent
- `item-row` 
   - use `next` instead of `later`
   - remove event logic from multi-select template
-  new component `layer-picker-row` 
   - shows the layer geometry type
   - will (eventually) enable/disable layer selection based on whitelist of geometry types 

Also adds docs describing the `item-picker`

Also - tests should pass.