### PR TITLE
Item picker qa issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+## Fixed
+- Sidebar now takes full height of the modal instead of taking the height of results
 
 ## [1.0.0]
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ## Fixed
 - Sidebar now takes full height of the modal instead of taking the height of results
+## Changed
+- Text of preview back button is now 'Close'
 
 ## [1.0.0]
 ## Added

--- a/addon/components/item-picker/feature-service-preview/template.hbs
+++ b/addon/components/item-picker/feature-service-preview/template.hbs
@@ -38,7 +38,7 @@
     <button type="button" class="btn btn-primary" data-test="item-picker-select-button" disabled={{isSelectDisabled}} {{action "onServiceSelected" model}}>{{selectButtonText}}</button>
   </div>
   <div class="side-by-side">
-    <button type="button" class="btn btn-default back-btn" {{action onCancel}}>{{t (concat _i18nScope "buttons.back")}}</button>
+    <button type="button" class="btn btn-default back-btn" {{action onCancel}}>{{t (concat _i18nScope "buttons.close")}}</button>
     <a href="{{previewUrl}}" target="_blank" class="btn btn-default preview-btn">{{t (concat _i18nScope "buttons.preview")}}</a>
   </div>
 </section>

--- a/addon/components/item-picker/item-preview/template.hbs
+++ b/addon/components/item-picker/item-preview/template.hbs
@@ -21,7 +21,7 @@
       <button type="button" class="btn btn-primary" data-test="item-picker-select-button" {{action onItemSelected model.item}}>{{selectButtonText}}</button>
     </div>
     <div class="side-by-side">
-      <button type="button" class="btn btn-default back-btn" {{action onCancel}}>{{t (concat _i18nScope "buttons.back")}}</button>
+      <button type="button" class="btn btn-default back-btn" {{action onCancel}}>{{t (concat _i18nScope "buttons.close")}}</button>
       <a href="{{previewUrl}}" target="_blank" class="btn btn-default preview-btn">{{t (concat _i18nScope "buttons.preview")}}</a>
     </div>
 </section>

--- a/addon/components/item-picker/template.hbs
+++ b/addon/components/item-picker/template.hbs
@@ -17,6 +17,19 @@
     <div class="alert alert-{{currentStatus}}" role="alert">{{currentMessage}}</div>
   {{/if}}
 
+{{#if currentModel}}
+  <section class="item-picker-current-item">
+    {{component preview
+      _i18nScope=_i18nScope
+      model=currentModel
+      params=previewParams
+      onSelectionValidator=onSelectionValidator
+      onItemSelected=(action 'onPreviewSelected')
+      onCancel=(action 'cancelAction')
+    }}
+  </section>
+{{/if}}
+
 <div class="{{if showFacets "col-xs-10" "col-xs-12"}}">
     {{search-form q=q onSearch=(action "doSearch")}}
 
@@ -39,19 +52,6 @@
           {{/each}}
         {{/if}}
       </ul>
-
-      {{#if currentModel}}
-        <section class="item-picker-current-item">
-          {{component preview
-            _i18nScope=_i18nScope
-            model=currentModel
-            params=previewParams
-            onSelectionValidator=onSelectionValidator
-            onItemSelected=(action 'onPreviewSelected')
-            onCancel=(action 'cancelAction')
-          }}
-        </section>
-      {{/if}}
     </div>
 
     {{#if selectMultiple}}

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -196,7 +196,7 @@ div.panel-body:has(.item-picker) {
     z-index: 4;
     padding: 15px;
     position: absolute;
-    top: 0;
+    top: 33px;
     left: 55%;
     right: 0;
     bottom: 0;

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -229,7 +229,7 @@ div.panel-body:has(.item-picker) {
       }
       .item-picker-current-item-preview-description {
         overflow: hidden;
-        flex: 0 1 30%;
+        flex: 0 1 auto;
         position: relative;
         margin-top: 5%;
         .text-fade {

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -193,7 +193,7 @@ div.panel-body:has(.item-picker) {
   .item-picker-current-item {
     // This is styling for the drawer that
     // holds the metadata for the item
-    z-index: 3;
+    z-index: 4;
     padding: 15px;
     position: absolute;
     top: 0;
@@ -231,7 +231,7 @@ div.panel-body:has(.item-picker) {
         overflow: hidden;
         flex: 0 1 30%;
         position: relative;
-        margin: 5% 0px;
+        margin-top: 5%;
         .text-fade {
           width: 100%;
           height: 13px;

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -32,7 +32,7 @@
           "httpsNotSupported": "This service does not support HTTPS. Please update your server settings and try again."
         },
         "buttons": {
-          "back": "Back",
+          "close": "Close",
           "select": "Select",
           "validating": "Validating data...",
           "selectAnyway": "Select Anyway",


### PR DESCRIPTION
# Item picker issue discovered on QA

## Description
Fixes issue @ghudgins saw in QA with the sidebar by moving the sidebar code out of the item list and placing it above.

![image](https://user-images.githubusercontent.com/2423402/38141765-b5098870-3407-11e8-8518-4a0a37e10f93.png)


## New Unit and Integration Tests?
No, this was a style related update. No DOM changed, just structure and minor style tweaks.

## Hub End-to-End Tests Run?
Yes

## Item Picker Screen Caps
If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occured in the three main contexts it is used:

- item picker in normal modal

<img width="979" alt="regular modal" src="https://user-images.githubusercontent.com/2423402/38143443-951384ba-340e-11e8-90e5-dd4f6df116c5.png">


- item picker in full-screen modal
<img width="1680" alt="fullscreen" src="https://user-images.githubusercontent.com/2423402/38143437-8c85abde-340e-11e8-9794-4753e7deffbf.png">



- item picker in god modal

<img width="1614" alt="god modal" src="https://user-images.githubusercontent.com/2423402/38143433-87d77e3c-340e-11e8-9c8f-faadf547f277.png">

