### PR TITLE
76/tolowercase undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+## Fixed
+- Preview panel now closes when clicking an active row [link](https://github.com/Esri/ember-arcgis-portal-components/issues/76)
+- Sidebar now takes full height of the modal instead of taking the height of results
 
 ## [1.0.0]
 ## Added

--- a/addon/components/item-picker/template.hbs
+++ b/addon/components/item-picker/template.hbs
@@ -40,7 +40,7 @@
         {{/if}}
       </ul>
 
-      {{#if currentModel}}
+      {{#if currentModel.item}}
         <section class="item-picker-current-item">
           {{component preview
             _i18nScope=_i18nScope


### PR DESCRIPTION
# Side panel not closing on row click

## Description
Fixes the issue where the side panel wouldn't close if the active row was clicked again

[#83890](https://esriarlington.tpondemand.com/entity/83890-clicking-item-row-in-item-picker) && #76 

## Unit and Integration Tests
No. Minor adjustment.

## Hub End-to-End Tests Run?
No. Minor adjustment.

## Item Picker Screen Caps
- item picker in normal modal
<img width="964" alt="screen shot 2018-03-30 at 12 47 39 pm" src="https://user-images.githubusercontent.com/2423402/38145685-97d74934-3418-11e8-8dde-95a21ec58f40.png">

- item picker in full-screen modal
<img width="1680" alt="screen shot 2018-03-30 at 12 47 48 pm" src="https://user-images.githubusercontent.com/2423402/38145686-97fd723a-3418-11e8-9eb8-5007cd99226b.png">

- item picker in god modal
<img width="1606" alt="screen shot 2018-03-30 at 12 47 14 pm" src="https://user-images.githubusercontent.com/2423402/38145687-9878d3ee-3418-11e8-803b-342468fe9d92.png">

