### PR TITLE
Remove stray pull- from stylesheet and tooltips on hover

### DIFF
--- a/addon/components/item-picker/item-row/multiple/template.hbs
+++ b/addon/components/item-picker/item-row/multiple/template.hbs
@@ -5,7 +5,7 @@
     <span></span>
   </div>
   <div class="item-picker-item-results-item-inner">
-    <h2 title="{{model.title}}">
+    <h2>
       {{model.title}}
     </h2>
     <div class="shared-by">

--- a/addon/components/item-picker/item-row/multiple/template.hbs
+++ b/addon/components/item-picker/item-row/multiple/template.hbs
@@ -5,7 +5,7 @@
     <span></span>
   </div>
   <div class="item-picker-item-results-item-inner">
-    <h2>
+    <h2 title="{{model.title}}">
       {{model.title}}
     </h2>
     <div class="shared-by">

--- a/addon/components/item-picker/item-row/single/template.hbs
+++ b/addon/components/item-picker/item-row/single/template.hbs
@@ -1,7 +1,7 @@
 <span class="pull-right item-picker-item-results-item-type">{{typeOfData}}</span>
 <a href="" {{action 'selectItem' model}}>
   <div class="item-picker-item-results-item-inner">
-    <h2 title="{{model.title}}">
+    <h2>
       {{model.title}}
     </h2>
     <div class="shared-by">

--- a/addon/components/item-picker/item-row/single/template.hbs
+++ b/addon/components/item-picker/item-row/single/template.hbs
@@ -1,7 +1,7 @@
 <span class="pull-right item-picker-item-results-item-type">{{typeOfData}}</span>
 <a href="" {{action 'selectItem' model}}>
   <div class="item-picker-item-results-item-inner">
-    <h2 data-toggle="tooltip" title="{{model.title}}">
+    <h2 title="{{model.title}}">
       {{model.title}}
     </h2>
     <div class="shared-by">

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -1,4 +1,4 @@
-pull-.portal-search-form {
+.portal-search-form {
   border-bottom: 1px solid $calcite-gray-light;
   .clear-button {
     z-index: 10;


### PR DESCRIPTION
# Stylesheet issue and removing tooltips

## Description
Fixes stylesheet

## Unit and Integration Tests
No. Style tweak.

## Hub End-to-End Tests Run?
No. Style tweak.

## Item Picker Screen Caps

- Firefox (**NOTE: The issue with width in firefox is a monorepo issue, not an EAPC issue**)
<img width="1680" alt="screen shot 2018-04-02 at 9 08 53 am" src="https://user-images.githubusercontent.com/2423402/38197362-b4ce6a7e-3655-11e8-9832-4aa86499c157.png">

- Safari
<img width="1680" alt="screen shot 2018-04-02 at 9 08 41 am" src="https://user-images.githubusercontent.com/2423402/38197349-aa87ab2a-3655-11e8-845d-1984958a65c7.png">

- Chrome
<img width="1680" alt="screen shot 2018-04-02 at 9 09 04 am" src="https://user-images.githubusercontent.com/2423402/38197371-bd4aa9d8-3655-11e8-88e8-79bae27f645e.png">