### PR TITLE
Fadeout issue

### DIFF
--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -229,7 +229,7 @@ div.panel-body:has(.item-picker) {
       }
       .item-picker-current-item-preview-description {
         overflow: hidden;
-        flex: 0 1 auto;
+        flex: 1 1 auto;
         position: relative;
         margin-top: 5%;
         .text-fade {

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -257,11 +257,11 @@ div.panel-body:has(.item-picker) {
       background-color: $white;
       padding-top: 15px;
       .full-width-btn {
-        display: flex;
         margin-bottom: 15px;
         padding-left: 15px;
+        flex: 1 0 100%;
         button {
-          flex: 1;
+          width: 100%
         }
       }
       .side-by-side {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "repository": "https://github.com/Esri/ember-arcgis-portal-components",
   "scripts": {
     "build": "ember build",
+    "clean": "rm -rf node_modules bower_components",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
     "start": "ember serve",
     "test": "ember test --silent",


### PR DESCRIPTION
# Text fade fix

## Description
Fixes an issue found in QA of the text-fade being too high on the description due to flex box issue. It now sits at the bottom of the div as expected.

https://esriarlington.tpondemand.com/entity/83582-chore-side-panel-update-layout-to

## Unit and Integration Tests
No. Style tweak

## Hub End-to-End Tests Run? [NO]
No, style tweak

## Item Picker Screen Caps
Before:
![image](https://user-images.githubusercontent.com/2423402/38213002-d2c557ee-368d-11e8-953b-a93a64021c4e.png)

After:
![image](https://user-images.githubusercontent.com/2423402/38213030-e602f6a4-368d-11e8-9e82-24d8094e98e6.png)
