### PR TITLE
C/84646 padding eapc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,57 +5,59 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - replace ember-network w/ ember-fetch
+### Fixed
+- Padding issue on item picker modals [84646](https://esriarlington.tpondemand.com/entity/84646-chore-fixing-the-padding-issue-on)
 
 ## [1.0.4]
-## Fixed
+### Fixed
 - Style issue where the checkbox and title were not centered in the row in multi mode
 
 ## [1.0.3]
-## Fixed
+### Fixed
 - Text fadeout is now placed at the bottom of the description container instead of the description itself
 
 ## [1.0.2]
-## Fixed
+### Fixed
 - Removed stray string causing styling issues
-## Removed
+### Removed
 - Removed tooltips on hover of titles in item picker
 
 ## [1.0.1]
-## Fixed
+### Fixed
 - Preview panel now closes when clicking an active row [link](https://github.com/Esri/ember-arcgis-portal-components/issues/76)
 - Sidebar now takes full height of the modal instead of taking the height of results
-## Changed
+### Changed
 - Text of preview back button is now 'Close'
 
 ## [1.0.0]
-## Added
+### Added
 - magic-checkbox class is now used in multi-select mode
 - markdown docs for item-picker
-## Changed
+### Changed
 - `feature-service-preview` action-up with `{item, options}`
 - `item-row` selectItem action uses `next`
 - general cleanup and consistency for using `model` internally, and returning `{item, options}`
 - preview pane now uses flex box instead of absolute positioning
-## Fixed
+### Fixed
 - Checkboxes no longer jump in Safari when checked [link](https://esriarlington.tpondemand.com/entity/83629-filter-by-initiative-styling-issues-withtooltips)
 - On smaller screens, the “Select” button on the bottom right now has a fixed width [link](https://esriarlington.tpondemand.com/entity/83629-filter-by-initiative-styling-issues-withtooltips)
 - Old and unused classes have now been removed and the border is no longer visible in the monorepo [link](https://esriarlington.tpondemand.com/entity/83659-chore-search-classes-need-to-cleanup)
-## Removed
+### Removed
 - Extra padding on item picker has been removed [link](https://github.com/Esri/ember-arcgis-portal-components/issues/63)
 
 ## 0.9.4
-## Fixed
+### Fixed
 - Fix issue where checkboxes would not become active on click in multi-select mode [link](https://esriarlington.tpondemand.com/entity/83698-checkboxes-dont-have-active-state-on)
 
-## Removed
+### Removed
 - Removed unnecessary tooltip from title
 
 ## 0.9.3
-## Changed
+### Changed
 - More fixes for feature service preview to fix e2e tests
 
 ## 0.9.2
-## Changed
+### Changed
 - Updated feature service preview for e2e fix
 
 ## 0.9.1

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -20,7 +20,6 @@ div.panel-body:has(.item-picker) {
 .item-picker {
   position: relative;
   min-height: 45rem;
-  padding: 0% 2.5%;
   .item-picker-datasets-pane, .item-picker-items-pane {
     min-height: 55rem;
   }


### PR DESCRIPTION
# Fix EAPC padding

## Description
Removes item picker padding that was causing odd styling in Hub

Ticket: https://esriarlington.tpondemand.com/entity/84646-chore-fixing-the-padding-issue-on

## Unit and Integration Tests
No. Style update.

## Hub End-to-End Tests Run? [YES|NO]
No. Style update.

## Item Picker Screen Caps
If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occured in the three main contexts it is used:

- item picker in normal modal

<img width="1621" alt="screen shot 2018-05-03 at 9 04 25 am" src="https://user-images.githubusercontent.com/2423402/39578046-162ef482-4eb1-11e8-9c7c-4d0f820b2ba4.png">


- item picker in full-screen modal

<img width="933" alt="screen shot 2018-05-03 at 9 03 53 am" src="https://user-images.githubusercontent.com/2423402/39578051-18350302-4eb1-11e8-92c6-892140039044.png">


- item picker in god modal

<img width="1617" alt="screen shot 2018-05-03 at 9 04 37 am" src="https://user-images.githubusercontent.com/2423402/39578055-1cede242-4eb1-11e8-92a1-63e79bac4666.png">

