### PR TITLE
hides duplicate 'clear-input' pseudoelement in text inputs on IE/Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Hides duplicate 'clear-input' pseudoelement in text inputs on IE/Edge [83956](https://esriarlington.tpondemand.com/entity/83956)
 
 ## [1.0.6]
 ### Fixed

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -9,6 +9,9 @@
     box-shadow: none;
     -webkit-box-shadow: none;
   }
+  .input-group div.has-clear input::-ms-clear {
+    display: none;
+  }
   button {
     background-color: transparent;
     border: 0px;


### PR DESCRIPTION
# hides duplicate 'clear-input' pseudoelement in text inputs on IE/Edge

## Description
removes IE/edge browser default 'clear-input' X pseudoelement from inputs with our own clear-input functionality (removes duplicate X in IE/edge)

[83956](https://esriarlington.tpondemand.com/entity/83956-sites-search-bar-styling-in-ie)

## Unit and Integration Tests
Were any new tests added? If not, why not?
No. Style update.

## Hub End-to-End Tests Run? [YES|NO]
- if no, please note why they were not run
No. Style update.

## Item Picker Screen Caps
n/a, touches search form only
![ie-ms-clear](https://user-images.githubusercontent.com/11283135/41373780-4beddda2-6f1f-11e8-9f6f-df09ae703e1c.gif)

