### PR TITLE
B/persists selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Hides duplicate 'clear-input' pseudoelement in text inputs on IE/Edge [83956](https://esriarlington.tpondemand.com/entity/83956)
 
 ### Changed
-- item-picker will now check for previous selections on init
+- item-picker will now initialize with passed in selections if any are passed in
 
 ## [1.0.6]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Hides duplicate 'clear-input' pseudoelement in text inputs on IE/Edge [83956](https://esriarlington.tpondemand.com/entity/83956)
 
+### Changed
+- item-picker will now check for previous selections on init
+
 ## [1.0.6]
 ### Fixed
 - Padding issue on item picker modals [84646](https://esriarlington.tpondemand.com/entity/84646-chore-fixing-the-padding-issue-on)

--- a/addon/components/item-picker/component.js
+++ b/addon/components/item-picker/component.js
@@ -39,6 +39,9 @@ export default Component.extend({
   init () {
     this._super(...arguments);
     this.set('itemsToAdd', []);
+    if (this.get('priorSelections')) {
+      this.set('itemsToAdd', this.get('priorSelections'));
+    }
     if (this.get('searchItemsOnInit')) {
       if (this.get('catalog')) {
         this._setInitialCatalog(this.get('catalog'));

--- a/addon/components/item-picker/component.js
+++ b/addon/components/item-picker/component.js
@@ -38,9 +38,8 @@ export default Component.extend({
    */
   init () {
     this._super(...arguments);
-    this.set('itemsToAdd', []);
-    if (this.get('priorSelections')) {
-      this.set('itemsToAdd', this.get('priorSelections'));
+    if (!this.get('itemsToAdd')) {
+      this.set('itemsToAdd', []);
     }
     if (this.get('searchItemsOnInit')) {
       if (this.get('catalog')) {

--- a/addon/components/item-picker/item-row/component.js
+++ b/addon/components/item-picker/item-row/component.js
@@ -62,8 +62,7 @@ export default Component.extend({
   }),
 
   checked: computed('model.id', 'itemsToAdd.[]', function () {
-    let chk = this.get('itemsToAdd').includes(this.get('model'));
-    return chk;
+    return this.get('itemsToAdd').findBy('id', this.get('model.id'));
   }),
 
   url: computed('model.id', 'session.portalHostname', function () {

--- a/tests/integration/components/item-picker/component-test.js
+++ b/tests/integration/components/item-picker/component-test.js
@@ -1,7 +1,7 @@
 import { A } from '@ember/array';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, findAll } from '@ember/test-helpers';
+import {render, find, findAll} from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 
@@ -42,5 +42,38 @@ module('Integration | Component | item picker', function (hooks) {
     assert.equal(findAll('.item-picker-item-results-item').length, 1);
     assert.ok(!find('.item-picker-item-results-item').classList.contains('is-selected'));
     assert.equal(findAll('.item-picker-current-item').length, 0);
+  });
+
+  test('it respects passed in items as selections', async function (assert) {
+    const item = {
+      id: 'abc123',
+      title: 'This is item 1',
+      description: 'This is the first description',
+      owner: 'marvin',
+      modified: 1411060006000,
+      type: 'Web Map'
+    };
+    const item2 = {
+      id: 'def456',
+      title: 'This is item 2',
+      description: 'This is the second description',
+      owner: 'marvin',
+      modified: 1410060006000,
+      type: 'Web Map'
+    };
+    const items = A([item, item2]);
+    const selectedItems = [ item ];
+
+    this.setProperties({
+      items: { results: items },
+      selectedItems,
+      selectAction () {}
+    });
+
+    await render(hbs`{{item-picker items=items selectMultiple=true itemsToAdd=selectedItems selectAction=(action selectAction)}}`);
+
+    assert.equal(findAll('.item-picker-item-results-item').length, 2);
+    assert.ok(findAll('.item-picker-item-results-item input:checked').length);
+    assert.ok(findAll('.item-picker-item-results-item input:not(:checked)').length);
   });
 });


### PR DESCRIPTION
B/persist selections 

## Description
- If an array of prior selections/items is passed to it, the item picker will initialize with those items selected.
- Item picker selections will be maintained through page changes 

[#83918](https://esriarlington.tpondemand.com/entity/83918)

## Unit and Integration Tests
Yes. Added an integration test for the item picker.  

## Hub End-to-End Tests Run? [YES|NO]
Yes. All are passing. 

## Item Picker Screen Caps
If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occured in the three main contexts it is used:

- item picker in normal modal
<img width="1225" alt="screen shot 2018-06-25 at 1 31 53 pm" src="https://user-images.githubusercontent.com/13521927/41870949-7f2d7658-788b-11e8-94be-6a5294f5d422.png">


- item picker in full-screen modal

<img width="1224" alt="screen shot 2018-06-25 at 3 12 36 pm" src="https://user-images.githubusercontent.com/13521927/41870966-8b1574a2-788b-11e8-9059-429cf81c4c1c.png">


- item picker in god modal

<img width="1230" alt="screen shot 2018-06-25 at 1 34 41 pm" src="https://user-images.githubusercontent.com/13521927/41870978-94d6bb5e-788b-11e8-92d8-b74f97c076e5.png">
