### PR TITLE
Adding verticalFlex mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added vertical flex mode [85042](https://esriarlington.tpondemand.com/entity/85042-modals-minimum-height-is-very-tall)
+
 ### Fixed
 - Hides duplicate 'clear-input' pseudoelement in text inputs on IE/Edge [83956](https://esriarlington.tpondemand.com/entity/83956)
 

--- a/addon/components/item-picker/component.js
+++ b/addon/components/item-picker/component.js
@@ -23,6 +23,7 @@ import isGuid from 'ember-arcgis-portal-components/utils/is-guid';
 
 export default Component.extend({
   classNames: [ 'item-picker', 'clearfix' ],
+  classNameBindings: ['verticalFlex:item-picker-vertical-flex'],
   disableAddItems: not('hasItemsToAdd'),
   hasItemsToAdd: notEmpty('itemsToAdd'),
   intl: service(),
@@ -33,6 +34,9 @@ export default Component.extend({
   shouldValidate: false,
   showMessage: notEmpty('currentMessage'),
   showNoItemsMsg: notEmpty('noItemsFoundMsg'),
+  // responsiveHeight mode == the component will only show 8 items per page and flex with
+  // the height of the screen... especially useful for responsive modals
+  verticalFlex: false,
   /**
    * Startup the component... we may need to issue an immediate search...
    */
@@ -102,8 +106,12 @@ export default Component.extend({
 
   query: '',
 
-  pageSize: computed(function () {
-    return this.get('rowCount') || 10;
+  defaultPageSize: computed('disableFlexyMode', function () {
+    return this.get('disableFlexyMode') ? 10 : 8;
+  }),
+
+  pageSize: computed('defaultPageSize', function () {
+    return this.get('rowCount') || this.get('defaultPageSize');
   }),
 
   items: A([]),

--- a/addon/components/item-picker/item-row/single/template.hbs
+++ b/addon/components/item-picker/item-row/single/template.hbs
@@ -5,7 +5,6 @@
       {{model.title}}
     </h2>
     <div class="shared-by">
-      howdy
       {{model.owner}}
     </div>
   </div>

--- a/addon/components/item-picker/item-row/single/template.hbs
+++ b/addon/components/item-picker/item-row/single/template.hbs
@@ -5,6 +5,7 @@
       {{model.title}}
     </h2>
     <div class="shared-by">
+      howdy
       {{model.owner}}
     </div>
   </div>

--- a/addon/components/item-picker/template.hbs
+++ b/addon/components/item-picker/template.hbs
@@ -1,21 +1,21 @@
-  {{#if showFacets}}
-    <div class="item-picker-radio-buttons col-xs-2">
-      {{#each catalog as |appType|}}
-        {{#radio-button
-          value=appType.name
-          groupValue=selectedCatalogName
-          changed="chooseCatalog"
-          classNames=(concat "item-picker-radio-button-" (dasherize appType.name))
-        }}
-          <span>{{appType.name}}</span>
-        {{/radio-button}}
-      {{/each}}
-    </div>
-  {{/if}}
+{{#if showFacets}}
+  <div class="item-picker-radio-buttons col-xs-2">
+    {{#each catalog as |appType|}}
+      {{#radio-button
+        value=appType.name
+        groupValue=selectedCatalogName
+        changed="chooseCatalog"
+        classNames=(concat "item-picker-radio-button-" (dasherize appType.name))
+      }}
+        <span>{{appType.name}}</span>
+      {{/radio-button}}
+    {{/each}}
+  </div>
+{{/if}}
 
-  {{#if showMessage}}
-    <div class="alert alert-{{currentStatus}}" role="alert">{{currentMessage}}</div>
-  {{/if}}
+{{#if showMessage}}
+  <div class="alert alert-{{currentStatus}}" role="alert">{{currentMessage}}</div>
+{{/if}}
 
 {{#if currentModel.item}}
   <section class="item-picker-current-item">
@@ -30,7 +30,7 @@
   </section>
 {{/if}}
 
-<div class="{{if showFacets "col-xs-10" "col-xs-12"}}">
+<div class="results-col {{if showFacets "col-xs-10" "col-xs-12"}}">
     {{search-form q=q onSearch=(action "doSearch")}}
 
     <div class="item-picker-results-container">

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -40,10 +40,16 @@ div.panel-body:has(.item-picker) {
   }
   ul.results-list {
     padding: 0;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    height: 100%;
     li:nth-child(even) {
       background: $calcite-gray-lightest
     }
     li {
+      overflow: hidden;
+      flex: 1;
       list-style: none;
       padding: 0;
       a {
@@ -328,6 +334,7 @@ div.panel-body:has(.item-picker) {
   }
   .item-picker-results-container {
     margin: 25px 0px;
+    height: 100%;
   }
   .flex-row {
     display: flex;
@@ -413,5 +420,35 @@ div.panel-body:has(.item-picker) {
   }
   .magic-radio:checked[disabled]+label:after {
     background: $calcite-blue-dark;
+  }
+}
+
+// These media queries are not nested in their elements because they only
+// apply if .item-picker-vertical-flex is applied.
+.item-picker-vertical-flex {
+  @media screen and (max-height: 940px) {
+    height: calc(100vh - 300px);
+    .results-col {
+      height:calc(#{100vh} - 415px);
+    }
+  }
+
+  @media screen and (max-height: 785px) {
+    .results-col ul.results-list li a .shared-by {
+      font-size: 10px;
+    }
+  }
+
+  @media screen and (max-height: 760px) {
+    .results-col ul.results-list li a .shared-by {
+      display: none;
+    }
+  }
+
+  @media screen and (max-height: 750px) {
+    height: 450px;
+    .results-col {
+      height: 335px;
+    }
   }
 }

--- a/docs/item-picker.md
+++ b/docs/item-picker.md
@@ -8,6 +8,7 @@ The Item Picker encapsulates the selection of Items. At first this seems like a 
 |----|:-------:|:-------:|----------|
 |  [selectAction](#basic-usage) | Function<br><small>(Closure Action)</small> | Yes | This action is run when the `Select` button inside the item picker is pressed. This should be a closure action. |
 |  [searchItemsOnInit](#basic-usage) | Boolean | No | Allows the item picker to execute a search and show the results as soon as it is rendered. This searches the active catalog on launch. If no active catalog is set, it will use the first available catalog. |
+|  [verticalFlex](#basic-usage) | Boolean | No | If set to true, the component will become vertically responsive at screen height 940px |
 |  [selectMultiple](#multiple-selection) | Boolean |  No|  Allows the item picker to select multiple items at once. An <strong>array</strong> of items will be passed to the closure action.   |
 |  [catalog](#filterin-and-faceting)  |  Array |  No | Allows the item picker to be filtered based on ArcGIS Online (AGO) queries. If the `catalog` array has more than one entry, a "facets" list will be shown on the left of the component, and it will use the `name` property. |
 |  [onSelectionValidator](#item-validation) | Function<br><small>(Closure Action)</small>  | No | Allows an application to do more in-depth validation of an item before using it. |
@@ -55,6 +56,14 @@ By default, the item picker will wait for the user to enter a query before issui
 ```hbs
 {{item-picker
     searchItemsOnInit=true
+    selectAction=(action "onSelectItem")}}
+```
+
+Also by default, the item picker has a set height. If verticalFlex is set to true, it will begin to be responsive at screen height 980px. This feature is designed for use in modals.
+
+```hbs
+{{item-picker
+    verticalFlex=true
     selectAction=(action "onSelectItem")}}
 ```
 

--- a/tests/integration/components/item-picker/component-test.js
+++ b/tests/integration/components/item-picker/component-test.js
@@ -76,4 +76,21 @@ module('Integration | Component | item picker', function (hooks) {
     assert.ok(findAll('.item-picker-item-results-item input:checked').length);
     assert.ok(findAll('.item-picker-item-results-item input:not(:checked)').length);
   });
+
+  test('Vertical flex mode toggles with verticalFlex attribute', async function (assert) {
+    this.setProperties({
+      items: { results: [] },
+      selectAction () {}
+    });
+
+    await render(hbs`{{item-picker verticalFlex=true items=items selectMultiple=true selectAction=(action selectAction)}}`);
+
+    assert.ok(this.element.querySelector('div').classList.contains('item-picker-vertical-flex'),
+      'item-picker-vertical-flex class added when verticalFlex == true');
+
+    await render(hbs`{{item-picker verticalFlex=false items=items selectMultiple=true selectAction=(action selectAction)}}`);
+
+    assert.notOk(this.element.querySelector('div').classList.contains('item-picker-vertical-flex'),
+      'item-picker-vertical-flex class NOT added when verticalFlex != true');
+  });
 });


### PR DESCRIPTION
# Adding verticalFlex mode

## Description
Adds the option to make item-picker more vertically responsive for use in modals in smaller screens.

[bug](https://esriarlington.tpondemand.com/entity/85042-modals-minimum-height-is-very-tall)

## Unit and Integration Tests
Yes, a test was added to make sure that the css toggles appropriately with the value of the `verticalFlex` attribute.

## Hub End-to-End Tests Run? [YES]

## Item Picker Screen Caps
If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has ocurred in the three main contexts it is used:

- item picker in normal modal

![screen shot 2018-07-25 at 11 07 11 am](https://user-images.githubusercontent.com/315764/43209552-eb55424e-8ffa-11e8-9094-d41e79af5204.png)

- item picker in full-screen modal

<img width="721" alt="screen shot 2018-07-25 at 10 59 18 am" src="https://user-images.githubusercontent.com/315764/43209103-deafbdea-8ff9-11e8-9f91-97ad181aaf7c.png">

- item picker in god modal

![screen shot 2018-07-25 at 12 32 00 pm](https://user-images.githubusercontent.com/315764/43214479-5be1b6f8-9007-11e8-8659-f0e0ff136b0d.png)

