### PR TITLE
bump to torii-provider-arcgis 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- bump to torii-provider-arcgis 2.0
+
 ## [1.2.0]
 ### Added
 - Added vertical flex mode [85042](https://esriarlington.tpondemand.com/entity/85042-modals-minimum-height-is-very-tall)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "loader.js": "^4.2.3",
     "torii": "0.10.1",
-    "torii-provider-arcgis": "1.2.0"
+    "torii-provider-arcgis": "^2.0.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7939,9 +7939,9 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-torii-provider-arcgis@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/torii-provider-arcgis/-/torii-provider-arcgis-1.2.0.tgz#c1d1c882ee38eba6b3d82400a954273f256f092b"
+torii-provider-arcgis@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/torii-provider-arcgis/-/torii-provider-arcgis-2.0.0.tgz#35f9d687686b3cb04cd2873b8d57792997c67848"
   dependencies:
     "@esri/arcgis-rest-auth" "^1.7.1"
     "@esri/arcgis-rest-request" "^1.7.1"


### PR DESCRIPTION
it's only a devDependency for this addon (i.e. for dummy app), just doing this to be in sync w/ the rest of the Hub apps/addons.