### PR TITLE
remove jQuery from addon; prevent future use & warn about it in tests/dummy app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ module.exports = {
       },
       rules: {
         // warn against use of jQuery in tests
-        "ember/no-jquery": 0
+        "ember/no-jquery": 1
       }
     },
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,9 +19,8 @@ module.exports = {
     "comma-dangle": [2, "only-multiline"],
     "no-console": 0,
     "no-extra-boolean-cast": 0,
-    // warn against future uses of jQuery
-    // TODO: set this to level 2 (error) once existing uses are replaced
-    "ember/no-jquery": 1
+    // don't allow uses of jQuery
+    "ember/no-jquery": 2
   },
   globals: {
     "_": false,
@@ -67,7 +66,7 @@ module.exports = {
         embertest: true
       },
       rules: {
-        // TODO: bump this to level 1 (warn) once we're ready to remove jQuery from tests
+        // warn against use of jQuery in tests
         "ember/no-jquery": 0
       }
     },
@@ -76,8 +75,8 @@ module.exports = {
     {
       files: ['tests/dummy/**/*.js'],
       rules: {
-        // TODO: bump this to level 1 (warn) once we're ready to remove jQuery from the dummy app
-        "ember/no-jquery": 0
+        // warn against use of jQuery in the dummy app
+        "ember/no-jquery": 1
       }
     }
   ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,10 @@ module.exports = {
   rules: {
     "comma-dangle": [2, "only-multiline"],
     "no-console": 0,
-    "no-extra-boolean-cast": 0
+    "no-extra-boolean-cast": 0,
+    // warn against future uses of jQuery
+    // TODO: set this to level 2 (error) once existing uses are replaced
+    "ember/no-jquery": 1
   },
   globals: {
     "_": false,
@@ -62,6 +65,19 @@ module.exports = {
       excludedFiles: ['tests/dummy/**/*.js'],
       env: {
         embertest: true
+      },
+      rules: {
+        // TODO: bump this to level 1 (warn) once we're ready to remove jQuery from tests
+        "ember/no-jquery": 0
+      }
+    },
+
+    // dummy app files
+    {
+      files: ['tests/dummy/**/*.js'],
+      rules: {
+        // TODO: bump this to level 1 (warn) once we're ready to remove jQuery from the dummy app
+        "ember/no-jquery": 0
       }
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- configure eslint to warn against use of jQuery
+- remove unnecessary uses of jQuery
+- configure eslint to disallow use of jQuery in addon
 
 ## [1.2.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- configure eslint to warn against use of jQuery
+
 ## [1.2.1]
 ### Changed
 - bump to ember-arcgis-portal-services 1.7.1 & torii-provider-arcgis 2.0

--- a/addon/components/item-picker/feature-service-preview/component.js
+++ b/addon/components/item-picker/feature-service-preview/component.js
@@ -236,8 +236,7 @@ export default Component.extend({
   didRender () {
     // Needed to jump to error message
     if (this.get('showError')) {
-      // TODO: replace w/ https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
-      this.$().scrollTop(0);
+      this.element.scrollTop = 0;
     }
   },
 

--- a/addon/components/item-picker/feature-service-preview/component.js
+++ b/addon/components/item-picker/feature-service-preview/component.js
@@ -236,6 +236,7 @@ export default Component.extend({
   didRender () {
     // Needed to jump to error message
     if (this.get('showError')) {
+      // TODO: replace w/ https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
       this.$().scrollTop(0);
     }
   },

--- a/addon/components/item-picker/item-preview/component.js
+++ b/addon/components/item-picker/item-preview/component.js
@@ -26,8 +26,7 @@ export default Component.extend({
   didRender () {
     // Needed to jump to error message
     if (this.get('showError')) {
-      // TODO: replace w/ https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
-      this.$().scrollTop(0);
+      this.element.scrollTop = 0;
     }
   },
 

--- a/addon/components/item-picker/item-preview/component.js
+++ b/addon/components/item-picker/item-preview/component.js
@@ -26,6 +26,7 @@ export default Component.extend({
   didRender () {
     // Needed to jump to error message
     if (this.get('showError')) {
+      // TODO: replace w/ https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop
       this.$().scrollTop(0);
     }
   },

--- a/addon/components/item-picker/item-row/component.js
+++ b/addon/components/item-picker/item-row/component.js
@@ -32,22 +32,6 @@ export default Component.extend({
   classNames: ['item-picker-item-results-item'],
   classNameBindings: ['isSelected', 'selectMultiple'],
 
-  // TODO: remove these hooks that are just used to init/destroy tooltips
-  // the templates don't even have tooltips
-  didInsertElement () {
-    const el = this.$('[data-toggle="tooltip"]');
-    if (el.tooltip) {
-      el.tooltip();
-    }
-  },
-
-  willDestroyElement () {
-    const el = this.$('[data-toggle="tooltip"]');
-    if (el.tooltip) {
-      el.tooltip('destroy');
-    }
-  },
-
   isSelected: computed('currentItemId', 'model.id', function () {
     return this.get('currentItemId') === this.get('model.id');
   }),

--- a/addon/components/item-picker/item-row/component.js
+++ b/addon/components/item-picker/item-row/component.js
@@ -32,6 +32,8 @@ export default Component.extend({
   classNames: ['item-picker-item-results-item'],
   classNameBindings: ['isSelected', 'selectMultiple'],
 
+  // TODO: remove these hooks that are just used to init/destroy tooltips
+  // the templates don't even have tooltips
   didInsertElement () {
     const el = this.$('[data-toggle="tooltip"]');
     if (el.tooltip) {


### PR DESCRIPTION
# PR Title
No jQuery in addon (still in tests/dummy app)

## Description
[86289](https://esriarlington.tpondemand.com/entity/86289-eacs-use-emberno-jquery-eslint-rule)

Remove uses of jQuery in the addon. Configure eslint to error on future uses in the addon code.

jQuery is still in the tests/dummy app. eslint is configured to show warnings for these uses.

**NOTE**: the only risk in this PR is removing jQuery from the addon, so I isolated that to it's own commit 11ad23c. I think the changes I've made are safe, but more importantly, they'll be easy to fix if anything crops up.

## Unit and Integration Tests
No. Refactor.

## Hub End-to-End Tests Run? [YES|NO]
Yes

```bash
==================================================================
Number of specs: 12


223 passing (124.50s)
```

## Item Picker Screen Caps

- item picker in normal modal

**paste image here**

<img width="719" alt="image" src="https://user-images.githubusercontent.com/662944/44883202-30806880-ac6b-11e8-8a22-49b0e661d914.png">

- item picker in full-screen modal

dunno where to get one of these

- item picker in god modal

<img width="1670" alt="image" src="https://user-images.githubusercontent.com/662944/44883356-a4227580-ac6b-11e8-8018-4d4a14da03f9.png">

