### PR TITLE
adds a11y labels to buttons on search-form component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+- added a11y labels to buttons on `search-form` component for screen readers [86518](https://esriarlington.tpondemand.com/entity/86518)
+
 ## [1.2.3]
 ### Changed
 - configure eslint to disallow use of global fetch [86117](https://esriarlington.tpondemand.com/entity/86117-eapc-use-eslint-no-restricted-globals)

--- a/addon/components/search-form/template.hbs
+++ b/addon/components/search-form/template.hbs
@@ -1,12 +1,12 @@
 <div class="input-group pull-left">
   <span class="input-group-btn">
-    <button type="submit" class="btn"><span class="glyphicon glyphicon-search"></span></button>
+    <button type="submit" class="btn" ><span class="glyphicon glyphicon-search" aria-label="{{t (concat _i18nScope 'aria.search')}}"></span></button>
   </span>
   <div class="has-feedback has-clear">
     <label for="{{inputElementId}}" class="sr-only">{{if placeholder placeholder (t placeholderi18nKey)}}:</label>
     <input autocomplete={{if autocomplete autocomplete 'off'}} id={{inputElementId}} value={{readonly _q}} class="form-control" placeholder={{if placeholder placeholder (t placeholderi18nKey)}} oninput={{action (mut _q) value="target.value"}} >
     {{#if _q}}
-      <button class="form-control-feedback clear-button" {{action 'cancel'}}><span class="glyphicon glyphicon-remove"></span></button>
+      <button class="form-control-feedback clear-button" {{action 'cancel'}}><span class="glyphicon glyphicon-remove" aria-label="{{t (concat _i18nScope 'aria.clear')}}"></span></button>
     {{/if}}
   </div>
 </div>

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -5,7 +5,11 @@
         "defaultMessage":"Loading..."
       },
       "searchForm": {
-        "searchItems":"Search items"
+        "searchItems":"Search items",
+        "aria": {
+          "search": "Submit Search",
+          "clear": "Clear Search results"
+        }
       },
       "itemPicker": {
         "searchDatasets": "Search datasets",


### PR DESCRIPTION
# Adds a11y label to the buttons on `search-form` component

Bug: [86518](https://esriarlington.tpondemand.com/entity/86518)

## Unit and Integration Tests
No. This PR only adds an `aria-label` attribute to preexisting buttons. 

## Hub End-to-End Tests Run? [YES|NO]
No, what I believe are local issues with my machine are preventing me from running them. I'm going to see if someone else can pull this branch and run them first. 

## Item Picker Screen Caps
This doesn't touch the item picker.