### PR TITLE
item picker facets a11y

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Were any new tests added? If not, why not?
 - if no, please note why they were not run
 
 ## Item Picker Screen Caps
-If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occured in the three main contexts it is used:
+If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occurred in the three main contexts it is used:
 
 - item picker in normal modal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [Unreleased]
+### Fixed
+- a11y of facets radio button list on `item-picker` component so they are keyboard navigable [86483](https://esriarlington.tpondemand.com/entity/86483-item-picker-facets-not-keyboard-navigable)
+
+## [1.2.4]
 ### Added
 - added a11y labels to buttons on `search-form` component for screen readers [86518](https://esriarlington.tpondemand.com/entity/86518)
 

--- a/addon/components/item-picker/template.hbs
+++ b/addon/components/item-picker/template.hbs
@@ -5,6 +5,7 @@
         value=appType.name
         groupValue=selectedCatalogName
         changed="chooseCatalog"
+        aria-label=appType.name
         classNames=(concat "item-picker-radio-button-" (dasherize appType.name))
       }}
         <span>{{appType.name}}</span>

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -170,7 +170,9 @@ div.panel-body:has(.item-picker) {
     padding-left: 0px;
     padding-right: 0px;
     [type="radio"] {
-      display: none;
+      position: absolute;
+      width: 1px;
+      opacity: 0;
     }
     label {
       display: block;
@@ -184,6 +186,10 @@ div.panel-body:has(.item-picker) {
       span {
         font-weight: normal;
       }
+    }
+    label:focus-within {
+      outline: $calcite-blue-core auto 5px;
+      outline: -webkit-focus-ring-color auto 5px;
     }
     label:first-of-type {
       border-top: 1px solid $calcite-gray-lightest;


### PR DESCRIPTION
# Item picker facets keyboard navigable

## Description
Makes facets radio buttons in item picker keyboard navigable and screen-reader accessbile

[bug](https://esriarlington.tpondemand.com/entity/86483-item-picker-facets-not-keyboard-navigable)

## Unit and Integration Tests
Were any new tests added? 
No, mostly a css change

## Hub End-to-End Tests Run? 
No, again mostly a css change

## Item Picker Screen Caps

- item picker in normal modal

N/A

- item picker in full-screen modal

![screen shot 2018-11-27 at 10 45 23 am](https://user-images.githubusercontent.com/11283135/49093195-98762900-f231-11e8-99ec-feffbf0860cb.png)

- item picker in god modal

N/A