### PR TITLE
bump the ea-server-services addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## 1.3.1
 ### Fixed
+- uses updated `ember-arcgis-server-services` version that *correctly* relies on ArcGIS-REST-JS
+
+## 1.3.0
+### Fixed
+- uses `ember-arcgis-server-services` version that relies on ArcGIS-REST-JS
 - a11y of facets radio button list on `item-picker` component so they are keyboard navigable [86483](https://esriarlington.tpondemand.com/entity/86483-item-picker-facets-not-keyboard-navigable)
 
 ## [1.2.4]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "calcite-bootstrap": "^0.4.4",
     "ember-arcgis-portal-services": "^1.12.0",
-    "ember-arcgis-server-services": "^1.7.0",
+    "ember-arcgis-server-services": "^1.7.1",
     "ember-bootstrap": "~2.0.0",
     "ember-cli": "~2.18.2",
     "ember-cli-app-version": "^3.0.0",


### PR DESCRIPTION
## Description
This simply picks up a bump in the ember-arcgis-server-services addon, ensuring that all methods either send auth to arcgis-rest-js OR use the request logic internal to that addon.


## Unit and Integration Tests
Were any new tests added? If not, why not? - Just a dep bump

## Hub End-to-End Tests Run? [YES|NO]
- if no, please note why they were not run - yes

## Item Picker Screen Caps - n/a

