### PR TITLE
Bump EA-SS Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.2
+### Fixed
+- uses updated `ember-arcgis-server-services` version which has corrected logic for when to send tokens to servers (fail-and-retry)
+
 ## 1.3.1
 ### Fixed
 - uses updated `ember-arcgis-server-services` version that *correctly* relies on ArcGIS-REST-JS

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "calcite-bootstrap": "^0.4.4",
     "ember-arcgis-portal-services": "^1.12.0",
-    "ember-arcgis-server-services": "^1.7.1",
+    "ember-arcgis-server-services": "^1.7.2",
     "ember-bootstrap": "~2.0.0",
     "ember-cli": "~2.18.2",
     "ember-cli-app-version": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,10 +2746,10 @@ ember-arcgis-portal-services@^1.12.0:
     ember-cli-htmlbars "^3.0.0"
     ember-fetch "^6.2.0"
 
-ember-arcgis-server-services@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/ember-arcgis-server-services/-/ember-arcgis-server-services-1.7.1.tgz#d2f185f0c46b9effccad70315ba065b156af3d5a"
-  integrity sha512-KMBbHrv8V2orlclPCaz6ejMkQti74yjj9tsk42cPuvPjGHwzZBZYGvjVAyEyoASnjUxxCK1wvYUrQ6v7URAqiw==
+ember-arcgis-server-services@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/ember-arcgis-server-services/-/ember-arcgis-server-services-1.7.2.tgz#ba2381a6a1d0a3b4e84849ed9922008ad6a84765"
+  integrity sha512-XMhLEkxzPoCS2rRquniS0RUKwNuFED/UwTGJ6Hgt7ilvguZf3fk/ow59Aon67It0i8Uj0jZqwd2gqiVyzo9zfQ==
   dependencies:
     "@esri/arcgis-rest-feature-service" "^1.14.3"
     "@esri/arcgis-rest-request" "^1.14.3"


### PR DESCRIPTION
Pick up a new version of the ember-arcgis-server-services addon which now correctly implements the same fail-and-retry logic as the JSAPI for determining when to send tokens to an ArcGIS Server.

No other changes.