### PR TITLE
adds focus state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Changed
 - upgraded ember-cli-sass
+- added focus state color to item-picker rows for a11y
 
 ## 1.3.2
 ### Fixed

--- a/app/styles/ember-arcgis-portal-components.scss
+++ b/app/styles/ember-arcgis-portal-components.scss
@@ -69,6 +69,9 @@ div.panel-body:has(.item-picker) {
           color: $off-black;
         }
       }
+      a:focus {
+        background-color: $calcite-blue-lightest;
+      }
       .item-picker-item-results-item-type {
         margin-top: 8px;
         margin-right: 10px;


### PR DESCRIPTION
# PR Title
Adds focus state

## Description
Adds focus state to item-picker search results

[Story|Bug](Link-to-tp)
- None
## Unit and Integration Tests
Were any new tests added? If not, why not?

- No. No value

## Hub End-to-End Tests Run? [YES|NO]
- if no, please note why they were not run
- No. Unable to run e2e currently and not a significant change

## Item Picker Screen Caps
If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occurred in the three main contexts it is used:

- item picker in normal modal
![normal](https://user-images.githubusercontent.com/13521927/57888368-fefefb80-77ff-11e9-8e2c-837f1e982252.gif)

- item picker in full-screen modal
![fullscreen](https://user-images.githubusercontent.com/13521927/57888381-04f4dc80-7800-11e9-92e6-974e6280dc38.gif)

- item picker in god modal

![god](https://user-images.githubusercontent.com/13521927/57888408-1b029d00-7800-11e9-92e4-f352f7f06155.gif)
