### PR TITLE
moves alert message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Changed
 - upgraded ember-cli-sass
+- moved `alert` message in item-picker to avoid collisions with facets in the DOM
 
 ## 1.3.2
 ### Fixed

--- a/addon/components/item-picker/template.hbs
+++ b/addon/components/item-picker/template.hbs
@@ -1,3 +1,7 @@
+{{#if showMessage}}
+  <div class="alert alert-{{currentStatus}}" role="alert">{{currentMessage}}</div>
+{{/if}}
+
 {{#if showFacets}}
   <div class="item-picker-radio-buttons col-xs-2">
     {{#each catalog as |appType|}}
@@ -12,10 +16,6 @@
       {{/radio-button}}
     {{/each}}
   </div>
-{{/if}}
-
-{{#if showMessage}}
-  <div class="alert alert-{{currentStatus}}" role="alert">{{currentMessage}}</div>
 {{/if}}
 
 {{#if currentModel.item}}


### PR DESCRIPTION
# PR Title
moves alert message
## Description
Description of what this PR does...
It just adjusts the alert message placement to avoid it colliding with facets.
[Story|Bug](Link-to-tp)
Doesn't exist, but discovered it while working on [90140](https://esriarlington.tpondemand.com/entity/90140-update-item-picker-for-selecting-initiative)
## Unit and Integration Tests
Were any new tests added? If not, why not?
- N/A
## Hub End-to-End Tests Run? [YES|NO]
- Yes

If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occurred in the three main contexts it is used:

**Before**
<img width="904" alt="Screen Shot 2019-05-22 at 9 14 06 AM" src="https://user-images.githubusercontent.com/13521927/58180164-9ab4bf80-7c77-11e9-9c3d-697e639a5ca4.png">

**After**
<img width="903" alt="Screen Shot 2019-05-22 at 9 17 33 AM" src="https://user-images.githubusercontent.com/13521927/58180205-aef8bc80-7c77-11e9-8552-936c15b31825.png">

<img width="1233" alt="Screen Shot 2019-05-22 at 9 59 41 AM" src="https://user-images.githubusercontent.com/13521927/58181150-46124400-7c79-11e9-8389-8b01731181c9.png">

<img width="1253" alt="Screen Shot 2019-05-22 at 10 00 21 AM" src="https://user-images.githubusercontent.com/13521927/58181207-5a564100-7c79-11e9-8ce8-9a36e851e95c.png">

