### PR TITLE
injects missing session into components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added focus state color to item-picker rows for a11y
 - moved `alert` message in item-picker to avoid collisions with facets in the DOM
 
+### Fixed
+- injected necessary `session` service into preview components in the `item-picker` [90782](https://esriarlington.tpondemand.com/entity/90782-webmap-picker-preview-adds-extra-https
+)
+
 ## 1.3.2
 ### Fixed
 - uses updated `ember-arcgis-server-services` version which has corrected logic for when to send tokens to servers (fail-and-retry)

--- a/addon/components/item-picker/feature-service-preview/component.js
+++ b/addon/components/item-picker/feature-service-preview/component.js
@@ -25,7 +25,6 @@ export default Component.extend({
   forceLayerSelection: reads('params.forceLayerSelection'),
   hasSelectedLayer: notEmpty('selectedLayer'),
   intl: service(),
-  session: service(),
   isLoading: true,
   isValidating: false,
   itemService: service('items-service'),

--- a/addon/components/item-picker/feature-service-preview/component.js
+++ b/addon/components/item-picker/feature-service-preview/component.js
@@ -25,6 +25,7 @@ export default Component.extend({
   forceLayerSelection: reads('params.forceLayerSelection'),
   hasSelectedLayer: notEmpty('selectedLayer'),
   intl: service(),
+  session: service(),
   isLoading: true,
   isValidating: false,
   itemService: service('items-service'),

--- a/addon/components/item-picker/item-preview/component.js
+++ b/addon/components/item-picker/item-preview/component.js
@@ -20,7 +20,6 @@ export default Component.extend({
   layout,
   intl: service(),
   items: service('items-service'),
-  session: service(),
 
   classNames: [ 'item-picker-current-item-preview' ],
 

--- a/addon/components/item-picker/item-preview/component.js
+++ b/addon/components/item-picker/item-preview/component.js
@@ -20,6 +20,7 @@ export default Component.extend({
   layout,
   intl: service(),
   items: service('items-service'),
+  session: service(),
 
   classNames: [ 'item-picker-current-item-preview' ],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,8 @@
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/@esri/arcgis-rest-users/-/arcgis-rest-users-1.14.3.tgz#d8800a74c3e8e1eba2964fec8e486251f8d7c437"
   integrity sha512-V6qTDJXSiN6gh67MRn+FOMRX3wdsshMvLnvZnQnnhQFxrKboOrb1f+/bbiKuvd5HrvxGkBsevoaQohd3W94RtQ==
+  dependencies:
+    tslib "^1.7.1"
 
 "@glimmer/di@^0.2.0":
   version "0.2.1"


### PR DESCRIPTION
# PR Title
`b/inject-session`
## Description
- injected necessary `session` service into preview components in the `item-picker`
- [90782](https://esriarlington.tpondemand.com/entity/90782-webmap-picker-preview-adds-extra-https)
## Unit and Integration Tests
Were any new tests added? If not, why not?
- No. I'll embark on adding acceptance tests to the site editor in the near future, which would be the right kind of test in this case.
 
## Hub End-to-End Tests Run? [YES|NO]
- Yes

## Item Picker Screen Caps
If the PR touches the `{{item-picker...` we want some screen caps to show that no visual regression has occurred in the three main contexts it is used:

- item picker in normal modal
<img width="1283" alt="Screen Shot 2019-06-03 at 2 47 29 PM" src="https://user-images.githubusercontent.com/13521927/58829103-00f4f700-8615-11e9-8acd-d295ca91652c.png">


- item picker in full-screen modal
<img width="677" alt="Screen Shot 2019-06-03 at 2 24 22 PM" src="https://user-images.githubusercontent.com/13521927/58829165-2bdf4b00-8615-11e9-9bb0-5735bb99f5e5.png">



- item picker in god modal
<img width="1346" alt="Screen Shot 2019-06-03 at 2 23 30 PM" src="https://user-images.githubusercontent.com/13521927/58829034-d014c200-8614-11e9-972b-bb0cd31ee834.png">